### PR TITLE
Added locale data for Pokémon

### DIFF
--- a/games/mk64/base_files/config.json
+++ b/games/mk64/base_files/config.json
@@ -1,9 +1,15 @@
 {
   "challonge_game_id": null,
   "locale": {
-    "jp": "マリオカート64",
-    "zh_CN": "马力欧卡丁车",
-    "zh_TW": "瑪利歐賽車64"
+    "ja": {
+      "name": "マリオカート64"
+    },
+    "zh_CN": {
+      "name": "马力欧卡丁车"
+    },
+    "zh_TW": {
+      "name": "瑪利歐賽車64"
+    }
   },
   "character_to_codename": {
     "Bowser": {
@@ -36,5 +42,5 @@
   "name": "Mario Kart 64",
   "smashgg_game_id": 5682,
   "stage_to_codename": {},
-  "version": "1.0"
+  "version": "1.01"
 }

--- a/games/msb/base_files/config.json
+++ b/games/msb/base_files/config.json
@@ -43,8 +43,10 @@
   "name": "Mario Superstar Baseball",
   "smashgg_game_id": 6660,
   "stage_to_codename": {},
-  "version": "1.0",
+  "version": "1.01",
   "locale": {
-    "jp": "スーパーマリオスタジアム ミラクルベースボール"
+    "ja": {
+      "name": "スーパーマリオスタジアム ミラクルベースボール"
+    }
   }
 }

--- a/games/msbl/base_files/config.json
+++ b/games/msbl/base_files/config.json
@@ -2,37 +2,113 @@
   "challonge_game_id": null,
   "character_to_codename": {
     "Bowser": {
-      "codename": "Bowser"
+      "codename": "Bowser",
+      "locale": {
+        "jp": "クッパ",
+        "zh_CN": "酷霸王",
+        "zh_TW": "酷霸王",
+        "ko": "쿠파"
+      }
     },
     "Donkey Kong": {
-      "codename": "DonkeyKong"
+      "codename": "DonkeyKong",
+      "locale": {
+        "jp": "ドンキーコング",
+        "zh_CN": "森喜刚",
+        "zh_TW": "森喜剛",
+        "ko": "동키콩"
+      }
     },
     "Luigi": {
-      "codename": "Luigi"
+      "codename": "Luigi",
+      "locale": {
+        "jp": "ルイージ",
+        "zh_CN": "路易吉",
+        "zh_TW": "路易吉",
+        "ko": "루이지"
+      }
     },
     "Mario": {
-      "codename": "Mario"
+      "codename": "Mario",
+      "locale": {
+        "jp": "マリオ",
+        "zh_CN": "马力欧",
+        "zh_TW": "瑪利歐",
+        "ko": "마리오"
+      }
     },
     "Peach": {
-      "codename": "Peach"
+      "codename": "Peach",
+      "locale": {
+        "jp": "ピーチ姫",
+        "zh_CN": "桃花公主",
+        "zh_TW": "碧琪公主",
+        "ko": "피치 공주"
+      }
     },
     "Rosalina": {
-      "codename": "Rosalina"
+      "codename": "Rosalina",
+      "locale": {
+        "fr_FR": "Harmonie",
+        "it": "Rosalinda",
+        "jp": "ロゼッタ",
+        "zh_CN": "罗莎塔",
+        "zh_TW": "羅潔塔",
+        "ko": "로젤리나",
+        "es_ES": "Estela"
+      }
     },
     "Toad": {
-      "codename": "Toad"
+      "codename": "Toad",
+      "locale": {
+        "jp": "キノピオ",
+        "zh_CN": "奇诺比奥",
+        "zh_TW": "奇諾比奧",
+        "ko": "키노피오"
+      }
     },
     "Waluigi": {
-      "codename": "Waluigi"
+      "codename": "Waluigi",
+      "locale": {
+        "jp": "ワルイージ",
+        "zh_CN": "瓦路易吉",
+        "zh_TW": "瓦路易吉",
+        "ko": "와루이지"
+      }
     },
     "Wario": {
-      "codename": "Wario"
+      "codename": "Wario",
+      "locale": {
+        "jp": "ワリオ",
+        "zh_CN": "瓦力欧",
+        "zh_TW": "瓦利歐",
+        "ko": "와리오"
+      }
     },
     "Yoshi": {
-      "codename": "Yoshi"
+      "codename": "Yoshi",
+      "locale": {
+        "jp": "ヨッシー",
+        "zh_CN": "耀西",
+        "zh_TW": "耀西",
+        "ko": "요시"
+      }
     },
     "Boom Boom": {
-      "codename": "BoomBoom"
+      "codename": "BoomBoom",
+      "locale": {
+        "jp": "ブンブン",
+        "zh_CN": "奔奔",
+        "zh_TW": "奔奔",
+        "ko": "부웅부웅",
+        "fr": "Boum Boum",
+        "de": "Bumm Bumm",
+        "it": "Boom-Boom",
+        "es_ES": "Bum Bum",
+        "es_US": "Bum bum",
+        "pt_BR": "Dom Dom",
+        "pt_PT": "Bum Bum"
+      }
     }
   },
   "credits": "",
@@ -67,6 +143,9 @@
       "name": "Mario Strikers: Battle League Football"
     },
     "es_ES": {
+      "name": "Mario Strikers: Battle League Football"
+    },
+    "pt_PT": {
       "name": "Mario Strikers: Battle League Football"
     }
   }

--- a/games/msbl/base_files/config.json
+++ b/games/msbl/base_files/config.json
@@ -40,16 +40,34 @@
   "name": "Mario Strikers: Battle League",
   "smashgg_game_id": 42285,
   "stage_to_codename": {},
-  "version": "1.0",
+  "version": "1.01",
   "locale": {
-    "jp": "マリオストライカーズ: バトルリーグ",
-    "zh_CN": "马力欧激战前锋 战斗联赛",
-    "zh_TW": "瑪利歐激戰前鋒 戰鬥聯賽",
-    "ko": "마리오 스트라이커즈 배틀 리그",
-    "fr_FR": "Mario Strikers: Battle League Football",
-    "it": "Mario Strikers: Battle League Football",
-    "de": "Mario Strikers: Battle League Football",
-    "nl": "Mario Strikers: Battle League Football",
-    "es_ES": "Mario Strikers: Battle League Football"
+    "ja": {
+      "name": "マリオストライカーズ: バトルリーグ"
+    },
+    "zh_CN": {
+      "name": "马力欧激战前锋 战斗联赛"
+    },
+    "zh_TW": {
+      "name": "瑪利歐激戰前鋒 戰鬥聯賽"
+    },
+    "ko": {
+      "name": "마리오 스트라이커즈 배틀 리그"
+    },
+    "fr_FR": {
+      "name": "Mario Strikers: Battle League Football"
+    },
+    "it": {
+      "name": "Mario Strikers: Battle League Football"
+    },
+    "de": {
+      "name": "Mario Strikers: Battle League Football"
+    },
+    "nl": {
+      "name": "Mario Strikers: Battle League Football"
+    },
+    "es_ES": {
+      "name": "Mario Strikers: Battle League Football"
+    }
   }
 }

--- a/games/msc/base_files/config.json
+++ b/games/msc/base_files/config.json
@@ -37,11 +37,35 @@
       "codename": "Yoshi"
     },
     "Petey Piranha": {
-      "codename": "Petey"
+      "codename": "Petey",
+      "locale": {
+        "fr_FR": "Flora Piranha",
+        "de": "Mutant-Tyranha",
+        "it": "Pipino Piranha",
+        "es_ES": "Floro Piraña",
+        "es_US": "Pepito piraña"
+      }
     }
   },
   "stage_to_codename": {},
-  "version": "1.01",
+  "version": "1.02",
   "description": "Base config to use this game.",
-  "credits": ""
+  "credits": "",
+  "locale": {
+    "fr_FR": {
+      "name": "Mario Strikers Charged Football"
+    },
+    "it": {
+      "name": "Mario Strikers Charged Football"
+    },
+    "de": {
+      "name": "Mario Strikers Charged Football"
+    },
+    "nl": {
+      "name": "Mario Strikers Charged Football"
+    },
+    "es_ES": {
+      "name": "Mario Strikers Charged Football"
+    }
+  }
 }

--- a/games/panel/base_files/config.json
+++ b/games/panel/base_files/config.json
@@ -46,8 +46,10 @@
   "name": "Panel de Pon",
   "smashgg_game_id": 34421,
   "stage_to_codename": {},
-  "version": "1.0",
-  "locale":{
-    "jp": "パネルでポン"
+  "version": "1.01",
+  "locale": {
+    "ja": {
+      "name": "パネルでポン"
+    }
   }
 }

--- a/games/panelna/base_files/config.json
+++ b/games/panelna/base_files/config.json
@@ -48,6 +48,8 @@
   "stage_to_codename": {},
   "version": "1.0",
   "locale": {
-    "jp": "ヨッシーのパネポン"
+    "ja": {
+      "name": "ヨッシーのパネポン"
+    }
   }
 }

--- a/games/pkmn/base_files/config.json
+++ b/games/pkmn/base_files/config.json
@@ -9962,5 +9962,20 @@
   "version": "1.16",
   "description": "Base config to use this game.",
   "credits": "Arclart for the Pok\u00e9mon Legends: Arceus icons",
-  "challonge_game_id": 159142
+  "challonge_game_id": 159142,
+  "locale": {
+    "fr": {
+      "description": "Configuration initial pour pouvoir charger ce jeu",
+      "credits": "Arclart pour les icones des Pokémon de Légendes Pokémon : Arceus"
+    },
+    "ja": {
+      "name": "ポケットモンスター"
+    },
+    "zh_CN": {
+      "name": "宝可梦"
+    },
+    "zh_TW": {
+      "name": "寶可夢"
+    }
+  }
 }

--- a/games/pkmn/base_files/config.json
+++ b/games/pkmn/base_files/config.json
@@ -3,2724 +3,9964 @@
   "smashgg_game_id": 15486,
   "character_to_codename": {
     "Bulbasaur": {
-      "codename": "001"
+      "codename": "001",
+      "locale": {
+        "fr": "Bulbizarre",
+        "de": "Bisasam",
+        "ko": "\uc774\uc0c1\ud574\uc528",
+        "ja": "\u30d5\u30b7\u30ae\u30c0\u30cd",
+        "zh_CN": "\u5999\u86d9\u79cd\u5b50",
+        "zh_TW": "\u5999\u86d9\u7a2e\u5b50"
+      }
     },
     "Ivysaur": {
-      "codename": "002"
+      "codename": "002",
+      "locale": {
+        "fr": "Herbizarre",
+        "de": "Bisaknosp",
+        "ko": "\uc774\uc0c1\ud574\ud480",
+        "ja": "\u30d5\u30b7\u30ae\u30bd\u30a6",
+        "zh_CN": "\u5999\u86d9\u8349",
+        "zh_TW": "\u5999\u86d9\u8349"
+      }
     },
     "Venusaur": {
-      "codename": "003"
+      "codename": "003",
+      "locale": {
+        "fr": "Florizarre",
+        "de": "Bisaflor",
+        "ko": "\uc774\uc0c1\ud574\uaf43",
+        "ja": "\u30d5\u30b7\u30ae\u30d0\u30ca",
+        "zh_CN": "\u5999\u86d9\u82b1",
+        "zh_TW": "\u5999\u86d9\u82b1"
+      }
     },
     "Charmander": {
-      "codename": "004"
+      "codename": "004",
+      "locale": {
+        "fr": "Salam\u00e8che",
+        "de": "Glumanda",
+        "ko": "\ud30c\uc774\ub9ac",
+        "ja": "\u30d2\u30c8\u30ab\u30b2",
+        "zh_CN": "\u5c0f\u706b\u9f99",
+        "zh_TW": "\u5c0f\u706b\u9f8d"
+      }
     },
     "Charmeleon": {
-      "codename": "005"
+      "codename": "005",
+      "locale": {
+        "fr": "Reptincel",
+        "de": "Glutexo",
+        "ko": "\ub9ac\uc790\ub4dc",
+        "ja": "\u30ea\u30b6\u30fc\u30c9",
+        "zh_CN": "\u706b\u6050\u9f99",
+        "zh_TW": "\u706b\u6050\u9f8d"
+      }
     },
     "Charizard": {
-      "codename": "006"
+      "codename": "006",
+      "locale": {
+        "fr": "Dracaufeu",
+        "de": "Glurak",
+        "ko": "\ub9ac\uc790\ubabd",
+        "ja": "\u30ea\u30b6\u30fc\u30c9\u30f3",
+        "zh_CN": "\u55b7\u706b\u9f99",
+        "zh_TW": "\u5674\u706b\u9f8d"
+      }
     },
     "Squirtle": {
-      "codename": "007"
+      "codename": "007",
+      "locale": {
+        "fr": "Carapuce",
+        "de": "Schiggy",
+        "ko": "\uaf2c\ubd80\uae30",
+        "ja": "\u30bc\u30cb\u30ac\u30e1",
+        "zh_CN": "\u6770\u5c3c\u9f9f",
+        "zh_TW": "\u5091\u5c3c\u9f9c"
+      }
     },
     "Wartortle": {
-      "codename": "008"
+      "codename": "008",
+      "locale": {
+        "fr": "Carabaffe",
+        "de": "Schillok",
+        "ko": "\uc5b4\ub2c8\ubd80\uae30",
+        "ja": "\u30ab\u30e1\u30fc\u30eb",
+        "zh_CN": "\u5361\u54aa\u9f9f",
+        "zh_TW": "\u5361\u54aa\u9f9c"
+      }
     },
     "Blastoise": {
-      "codename": "009"
+      "codename": "009",
+      "locale": {
+        "fr": "Tortank",
+        "de": "Turtok",
+        "ko": "\uac70\ubd81\uc655",
+        "ja": "\u30ab\u30e1\u30c3\u30af\u30b9",
+        "zh_CN": "\u6c34\u7bad\u9f9f",
+        "zh_TW": "\u6c34\u7bad\u9f9c"
+      }
     },
     "Caterpie": {
-      "codename": "010"
+      "codename": "010",
+      "locale": {
+        "fr": "Chenipan",
+        "de": "Raupy",
+        "ko": "\uce90\ud130\ud53c",
+        "ja": "\u30ad\u30e3\u30bf\u30d4\u30fc",
+        "zh_CN": "\u7eff\u6bdb\u866b",
+        "zh_TW": "\u7da0\u6bdb\u87f2"
+      }
     },
     "Metapod": {
-      "codename": "011"
+      "codename": "011",
+      "locale": {
+        "fr": "Chrysacier",
+        "de": "Safcon",
+        "ko": "\ub2e8\ub370\uae30",
+        "ja": "\u30c8\u30e9\u30f3\u30bb\u30eb",
+        "zh_CN": "\u94c1\u7532\u86f9",
+        "zh_TW": "\u9435\u7532\u86f9"
+      }
     },
     "Butterfree": {
-      "codename": "012"
+      "codename": "012",
+      "locale": {
+        "fr": "Papilusion",
+        "de": "Smettbo",
+        "ko": "\ubc84\ud130\ud50c",
+        "ja": "\u30d0\u30bf\u30d5\u30ea\u30fc",
+        "zh_CN": "\u5df4\u5927\u8776",
+        "zh_TW": "\u5df4\u5927\u8776"
+      }
     },
     "Weedle": {
-      "codename": "013"
+      "codename": "013",
+      "locale": {
+        "fr": "Aspicot",
+        "de": "Hornliu",
+        "ko": "\ubfd4\ucda9\uc774",
+        "ja": "\u30d3\u30fc\u30c9\u30eb",
+        "zh_CN": "\u72ec\u89d2\u866b",
+        "zh_TW": "\u7368\u89d2\u87f2"
+      }
     },
     "Kakuna": {
-      "codename": "014"
+      "codename": "014",
+      "locale": {
+        "fr": "Coconfort",
+        "de": "Kokuna",
+        "ko": "\ub531\ucda9\uc774",
+        "ja": "\u30b3\u30af\u30fc\u30f3",
+        "zh_CN": "\u94c1\u58f3\u86f9",
+        "zh_TW": "\u9435\u6bbc\u86f9"
+      }
     },
     "Beedrill": {
-      "codename": "015"
+      "codename": "015",
+      "locale": {
+        "fr": "Dardargnan",
+        "de": "Bibor",
+        "ko": "\ub3c5\uce68\ubd95",
+        "ja": "\u30b9\u30d4\u30a2\u30fc",
+        "zh_CN": "\u5927\u9488\u8702",
+        "zh_TW": "\u5927\u91dd\u8702"
+      }
     },
     "Pidgey": {
-      "codename": "016"
+      "codename": "016",
+      "locale": {
+        "fr": "Roucool",
+        "de": "Taubsi",
+        "ko": "\uad6c\uad6c",
+        "ja": "\u30dd\u30c3\u30dd",
+        "zh_CN": "\u6ce2\u6ce2",
+        "zh_TW": "\u6ce2\u6ce2"
+      }
     },
     "Pidgeotto": {
-      "codename": "017"
+      "codename": "017",
+      "locale": {
+        "fr": "Roucoups",
+        "de": "Tauboga",
+        "ko": "\ud53c\uc8e4",
+        "ja": "\u30d4\u30b8\u30e7\u30f3",
+        "zh_CN": "\u6bd4\u6bd4\u9e1f",
+        "zh_TW": "\u6bd4\u6bd4\u9ce5"
+      }
     },
     "Pidgeot": {
-      "codename": "018"
+      "codename": "018",
+      "locale": {
+        "fr": "Roucarnage",
+        "de": "Tauboss",
+        "ko": "\ud53c\uc8e4\ud22c",
+        "ja": "\u30d4\u30b8\u30e7\u30c3\u30c8",
+        "zh_CN": "\u5927\u6bd4\u9e1f",
+        "zh_TW": "\u5927\u6bd4\u9ce5"
+      }
     },
     "Rattata": {
-      "codename": "019"
+      "codename": "019",
+      "locale": {
+        "fr": "Rattata",
+        "de": "Rattfratz",
+        "ko": "\uaf2c\ub81b",
+        "ja": "\u30b3\u30e9\u30c3\u30bf",
+        "zh_CN": "\u5c0f\u62c9\u8fbe",
+        "zh_TW": "\u5c0f\u62c9\u9054"
+      }
     },
     "Raticate": {
-      "codename": "020"
+      "codename": "020",
+      "locale": {
+        "fr": "Rattatac",
+        "de": "Rattikarl",
+        "ko": "\ub808\ud2b8\ub77c",
+        "ja": "\u30e9\u30c3\u30bf",
+        "zh_CN": "\u62c9\u8fbe",
+        "zh_TW": "\u62c9\u9054"
+      }
     },
     "Spearow": {
-      "codename": "021"
+      "codename": "021",
+      "locale": {
+        "fr": "Piafabec",
+        "de": "Habitak",
+        "ko": "\uae68\ube44\ucc38",
+        "ja": "\u30aa\u30cb\u30b9\u30ba\u30e1",
+        "zh_CN": "\u70c8\u96c0",
+        "zh_TW": "\u70c8\u96c0"
+      }
     },
     "Fearow": {
-      "codename": "022"
+      "codename": "022",
+      "locale": {
+        "fr": "Rapasdepic",
+        "de": "Ibitak",
+        "ko": "\uae68\ube44\ub4dc\ub9b4\uc870",
+        "ja": "\u30aa\u30cb\u30c9\u30ea\u30eb",
+        "zh_CN": "\u5927\u5634\u96c0",
+        "zh_TW": "\u5927\u5634\u96c0"
+      }
     },
     "Ekans": {
-      "codename": "023"
+      "codename": "023",
+      "locale": {
+        "fr": "Abo",
+        "de": "Rettan",
+        "ko": "\uc544\ubcf4",
+        "ja": "\u30a2\u30fc\u30dc",
+        "zh_CN": "\u963f\u67cf\u86c7",
+        "zh_TW": "\u963f\u67cf\u86c7"
+      }
     },
     "Arbok": {
-      "codename": "024"
+      "codename": "024",
+      "locale": {
+        "fr": "Arbok",
+        "de": "Arbok",
+        "ko": "\uc544\ubcf4\ud06c",
+        "ja": "\u30a2\u30fc\u30dc\u30c3\u30af",
+        "zh_CN": "\u963f\u67cf\u602a",
+        "zh_TW": "\u963f\u67cf\u602a"
+      }
     },
     "Pikachu": {
-      "codename": "025"
+      "codename": "025",
+      "locale": {
+        "fr": "Pikachu",
+        "de": "Pikachu",
+        "ko": "\ud53c\uce74\uce04",
+        "ja": "\u30d4\u30ab\u30c1\u30e5\u30a6",
+        "zh_CN": "\u76ae\u5361\u4e18",
+        "zh_TW": "\u76ae\u5361\u4e18"
+      }
     },
     "Raichu": {
-      "codename": "026"
+      "codename": "026",
+      "locale": {
+        "fr": "Raichu",
+        "de": "Raichu",
+        "ko": "\ub77c\uc774\uce04",
+        "ja": "\u30e9\u30a4\u30c1\u30e5\u30a6",
+        "zh_CN": "\u96f7\u4e18",
+        "zh_TW": "\u96f7\u4e18"
+      }
     },
     "Sandshrew": {
-      "codename": "027"
+      "codename": "027",
+      "locale": {
+        "fr": "Sabelette",
+        "de": "Sandan",
+        "ko": "\ubaa8\ub798\ub450\uc9c0",
+        "ja": "\u30b5\u30f3\u30c9",
+        "zh_CN": "\u7a7f\u5c71\u9f20",
+        "zh_TW": "\u7a7f\u5c71\u9f20"
+      }
     },
     "Sandslash": {
-      "codename": "028"
+      "codename": "028",
+      "locale": {
+        "fr": "Sablaireau",
+        "de": "Sandamer",
+        "ko": "\uace0\uc9c0",
+        "ja": "\u30b5\u30f3\u30c9\u30d1\u30f3",
+        "zh_CN": "\u7a7f\u5c71\u738b",
+        "zh_TW": "\u7a7f\u5c71\u738b"
+      }
     },
     "Nidoran\u2640": {
-      "codename": "029"
+      "codename": "029",
+      "locale": {
+        "fr": "Nidoran\u2640",
+        "de": "Nidoran\u2640",
+        "ko": "\ub2c8\ub4dc\ub7f0\u2640",
+        "ja": "\u30cb\u30c9\u30e9\u30f3\u2640",
+        "zh_CN": "\u5c3c\u591a\u5170",
+        "zh_TW": "\u5c3c\u591a\u862d"
+      }
     },
     "Nidorina": {
-      "codename": "030"
+      "codename": "030",
+      "locale": {
+        "fr": "Nidorina",
+        "de": "Nidorina",
+        "ko": "\ub2c8\ub4dc\ub9ac\ub098",
+        "ja": "\u30cb\u30c9\u30ea\u30fc\u30ca",
+        "zh_CN": "\u5c3c\u591a\u5a1c",
+        "zh_TW": "\u5c3c\u591a\u5a1c"
+      }
     },
     "Nidoqueen": {
-      "codename": "031"
+      "codename": "031",
+      "locale": {
+        "fr": "Nidoqueen",
+        "de": "Nidoqueen",
+        "ko": "\ub2c8\ub4dc\ud038",
+        "ja": "\u30cb\u30c9\u30af\u30a4\u30f3",
+        "zh_CN": "\u5c3c\u591a\u540e",
+        "zh_TW": "\u5c3c\u591a\u540e"
+      }
     },
     "Nidoran\u2642": {
-      "codename": "032"
+      "codename": "032",
+      "locale": {
+        "fr": "Nidoran\u2642",
+        "de": "Nidoran\u2642",
+        "ko": "\ub2c8\ub4dc\ub7f0\u2642",
+        "ja": "\u30cb\u30c9\u30e9\u30f3\u2642",
+        "zh_CN": "\u5c3c\u591a\u6717",
+        "zh_TW": "\u5c3c\u591a\u6717"
+      }
     },
     "Nidorino": {
-      "codename": "033"
+      "codename": "033",
+      "locale": {
+        "fr": "Nidorino",
+        "de": "Nidorino",
+        "ko": "\ub2c8\ub4dc\ub9ac\ub178",
+        "ja": "\u30cb\u30c9\u30ea\u30fc\u30ce",
+        "zh_CN": "\u5c3c\u591a\u529b\u8bfa",
+        "zh_TW": "\u5c3c\u591a\u529b\u8afe"
+      }
     },
     "Nidoking": {
-      "codename": "034"
+      "codename": "034",
+      "locale": {
+        "fr": "Nidoking",
+        "de": "Nidoking",
+        "ko": "\ub2c8\ub4dc\ud0b9",
+        "ja": "\u30cb\u30c9\u30ad\u30f3\u30b0",
+        "zh_CN": "\u5c3c\u591a\u738b",
+        "zh_TW": "\u5c3c\u591a\u738b"
+      }
     },
     "Clefairy": {
-      "codename": "035"
+      "codename": "035",
+      "locale": {
+        "fr": "M\u00e9lof\u00e9e",
+        "de": "Piepi",
+        "ko": "\uc090\uc090",
+        "ja": "\u30d4\u30c3\u30d4",
+        "zh_CN": "\u76ae\u76ae",
+        "zh_TW": "\u76ae\u76ae"
+      }
     },
     "Clefable": {
-      "codename": "036"
+      "codename": "036",
+      "locale": {
+        "fr": "M\u00e9lodelfe",
+        "de": "Pixi",
+        "ko": "\ud53d\uc2dc",
+        "ja": "\u30d4\u30af\u30b7\u30fc",
+        "zh_CN": "\u76ae\u53ef\u897f",
+        "zh_TW": "\u76ae\u53ef\u897f"
+      }
     },
     "Vulpix": {
-      "codename": "037"
+      "codename": "037",
+      "locale": {
+        "fr": "Goupix",
+        "de": "Vulpix",
+        "ko": "\uc2dd\uc2a4\ud14c\uc77c",
+        "ja": "\u30ed\u30b3\u30f3",
+        "zh_CN": "\u516d\u5c3e",
+        "zh_TW": "\u516d\u5c3e"
+      }
     },
     "Ninetales": {
-      "codename": "038"
+      "codename": "038",
+      "locale": {
+        "fr": "Feunard",
+        "de": "Vulnona",
+        "ko": "\ub098\uc778\ud14c\uc77c",
+        "ja": "\u30ad\u30e5\u30a6\u30b3\u30f3",
+        "zh_CN": "\u4e5d\u5c3e",
+        "zh_TW": "\u4e5d\u5c3e"
+      }
     },
     "Jigglypuff": {
-      "codename": "039"
+      "codename": "039",
+      "locale": {
+        "fr": "Rondoudou",
+        "de": "Pummeluff",
+        "ko": "\ud478\ub9b0",
+        "ja": "\u30d7\u30ea\u30f3",
+        "zh_CN": "\u80d6\u4e01",
+        "zh_TW": "\u80d6\u4e01"
+      }
     },
     "Wigglytuff": {
-      "codename": "040"
+      "codename": "040",
+      "locale": {
+        "fr": "Grodoudou",
+        "de": "Knuddeluff",
+        "ko": "\ud478\ud06c\ub9b0",
+        "ja": "\u30d7\u30af\u30ea\u30f3",
+        "zh_CN": "\u80d6\u53ef\u4e01",
+        "zh_TW": "\u80d6\u53ef\u4e01"
+      }
     },
     "Zubat": {
-      "codename": "041"
+      "codename": "041",
+      "locale": {
+        "fr": "Nosferapti",
+        "de": "Zubat",
+        "ko": "\uc8fc\ubc43",
+        "ja": "\u30ba\u30d0\u30c3\u30c8",
+        "zh_CN": "\u8d85\u97f3\u8760",
+        "zh_TW": "\u8d85\u97f3\u8760"
+      }
     },
     "Golbat": {
-      "codename": "042"
+      "codename": "042",
+      "locale": {
+        "fr": "Nosferalto",
+        "de": "Golbat",
+        "ko": "\uace8\ubc43",
+        "ja": "\u30b4\u30eb\u30d0\u30c3\u30c8",
+        "zh_CN": "\u5927\u5634\u8760",
+        "zh_TW": "\u5927\u5634\u8760"
+      }
     },
     "Oddish": {
-      "codename": "043"
+      "codename": "043",
+      "locale": {
+        "fr": "Mystherbe",
+        "de": "Myrapla",
+        "ko": "\ub69c\ubc85\ucd78",
+        "ja": "\u30ca\u30be\u30ce\u30af\u30b5",
+        "zh_CN": "\u8d70\u8def\u8349",
+        "zh_TW": "\u8d70\u8def\u8349"
+      }
     },
     "Gloom": {
-      "codename": "044"
+      "codename": "044",
+      "locale": {
+        "fr": "Ortide",
+        "de": "Duflor",
+        "ko": "\ub0c4\uc0c8\uaf2c",
+        "ja": "\u30af\u30b5\u30a4\u30cf\u30ca",
+        "zh_CN": "\u81ed\u81ed\u82b1",
+        "zh_TW": "\u81ed\u81ed\u82b1"
+      }
     },
     "Vileplume": {
-      "codename": "045"
+      "codename": "045",
+      "locale": {
+        "fr": "Rafflesia",
+        "de": "Giflor",
+        "ko": "\ub77c\ud50c\ub808\uc2dc\uc544",
+        "ja": "\u30e9\u30d5\u30ec\u30b7\u30a2",
+        "zh_CN": "\u9738\u738b\u82b1",
+        "zh_TW": "\u9738\u738b\u82b1"
+      }
     },
     "Paras": {
-      "codename": "046"
+      "codename": "046",
+      "locale": {
+        "fr": "Paras",
+        "de": "Paras",
+        "ko": "\ud30c\ub77c\uc2a4",
+        "ja": "\u30d1\u30e9\u30b9",
+        "zh_CN": "\u6d3e\u62c9\u65af",
+        "zh_TW": "\u6d3e\u62c9\u65af"
+      }
     },
     "Parasect": {
-      "codename": "047"
+      "codename": "047",
+      "locale": {
+        "fr": "Parasect",
+        "de": "Parasek",
+        "ko": "\ud30c\ub77c\uc139\ud2b8",
+        "ja": "\u30d1\u30e9\u30bb\u30af\u30c8",
+        "zh_CN": "\u6d3e\u62c9\u65af\u7279",
+        "zh_TW": "\u6d3e\u62c9\u65af\u7279"
+      }
     },
     "Venonat": {
-      "codename": "048"
+      "codename": "048",
+      "locale": {
+        "fr": "Mimitoss",
+        "de": "Bluzuk",
+        "ko": "\ucf58\ud321",
+        "ja": "\u30b3\u30f3\u30d1\u30f3",
+        "zh_CN": "\u6bdb\u7403",
+        "zh_TW": "\u6bdb\u7403"
+      }
     },
     "Venomoth": {
-      "codename": "049"
+      "codename": "049",
+      "locale": {
+        "fr": "A\u00e9romite",
+        "de": "Omot",
+        "ko": "\ub3c4\ub098\ub9ac",
+        "ja": "\u30e2\u30eb\u30d5\u30a9\u30f3",
+        "zh_CN": "\u6469\u9c81\u86fe",
+        "zh_TW": "\u6469\u9b6f\u86fe"
+      }
     },
     "Diglett": {
-      "codename": "050"
+      "codename": "050",
+      "locale": {
+        "fr": "Taupiqueur",
+        "de": "Digda",
+        "ko": "\ub514\uadf8\ub2e4",
+        "ja": "\u30c7\u30a3\u30b0\u30c0",
+        "zh_CN": "\u5730\u9f20",
+        "zh_TW": "\u5730\u9f20"
+      }
     },
     "Dugtrio": {
-      "codename": "051"
+      "codename": "051",
+      "locale": {
+        "fr": "Triopikeur",
+        "de": "Digdri",
+        "ko": "\ub2e5\ud2b8\ub9ac\uc624",
+        "ja": "\u30c0\u30b0\u30c8\u30ea\u30aa",
+        "zh_CN": "\u4e09\u5730\u9f20",
+        "zh_TW": "\u4e09\u5730\u9f20"
+      }
     },
     "Meowth": {
-      "codename": "052"
+      "codename": "052",
+      "locale": {
+        "fr": "Miaouss",
+        "de": "Mauzi",
+        "ko": "\ub098\uc639",
+        "ja": "\u30cb\u30e3\u30fc\u30b9",
+        "zh_CN": "\u55b5\u55b5",
+        "zh_TW": "\u55b5\u55b5"
+      }
     },
     "Persian": {
-      "codename": "053"
+      "codename": "053",
+      "locale": {
+        "fr": "Persian",
+        "de": "Snobilikat",
+        "ko": "\ud398\ub974\uc2dc\uc628",
+        "ja": "\u30da\u30eb\u30b7\u30a2\u30f3",
+        "zh_CN": "\u732b\u8001\u5927",
+        "zh_TW": "\u8c93\u8001\u5927"
+      }
     },
     "Psyduck": {
-      "codename": "054"
+      "codename": "054",
+      "locale": {
+        "fr": "Psykokwak",
+        "de": "Enton",
+        "ko": "\uace0\ub77c\ud30c\ub355",
+        "ja": "\u30b3\u30c0\u30c3\u30af",
+        "zh_CN": "\u53ef\u8fbe\u9e2d",
+        "zh_TW": "\u53ef\u9054\u9d28"
+      }
     },
     "Golduck": {
-      "codename": "055"
+      "codename": "055",
+      "locale": {
+        "fr": "Akwakwak",
+        "de": "Entoron",
+        "ko": "\uace8\ub355",
+        "ja": "\u30b4\u30eb\u30c0\u30c3\u30af",
+        "zh_CN": "\u54e5\u8fbe\u9e2d",
+        "zh_TW": "\u54e5\u9054\u9d28"
+      }
     },
     "Mankey": {
-      "codename": "056"
+      "codename": "056",
+      "locale": {
+        "fr": "F\u00e9rosinge",
+        "de": "Menki",
+        "ko": "\ub9dd\ud0a4",
+        "ja": "\u30de\u30f3\u30ad\u30fc",
+        "zh_CN": "\u7334\u602a",
+        "zh_TW": "\u7334\u602a"
+      }
     },
     "Primeape": {
-      "codename": "057"
+      "codename": "057",
+      "locale": {
+        "fr": "Colossinge",
+        "de": "Rasaff",
+        "ko": "\uc131\uc6d0\uc22d",
+        "ja": "\u30aa\u30b3\u30ea\u30b6\u30eb",
+        "zh_CN": "\u706b\u7206\u7334",
+        "zh_TW": "\u706b\u7206\u7334"
+      }
     },
     "Growlithe": {
-      "codename": "058"
+      "codename": "058",
+      "locale": {
+        "fr": "Caninos",
+        "de": "Fukano",
+        "ko": "\uac00\ub514",
+        "ja": "\u30ac\u30fc\u30c7\u30a3",
+        "zh_CN": "\u5361\u8482\u72d7",
+        "zh_TW": "\u5361\u8482\u72d7"
+      }
     },
     "Arcanine": {
-      "codename": "059"
+      "codename": "059",
+      "locale": {
+        "fr": "Arcanin",
+        "de": "Arkani",
+        "ko": "\uc708\ub514",
+        "ja": "\u30a6\u30a4\u30f3\u30c7\u30a3",
+        "zh_CN": "\u98ce\u901f\u72d7",
+        "zh_TW": "\u98a8\u901f\u72d7"
+      }
     },
     "Poliwag": {
-      "codename": "060"
+      "codename": "060",
+      "locale": {
+        "fr": "Ptitard",
+        "de": "Quapsel",
+        "ko": "\ubc1c\ucc59\uc774",
+        "ja": "\u30cb\u30e7\u30ed\u30e2",
+        "zh_CN": "\u868a\u9999\u874c\u86aa",
+        "zh_TW": "\u868a\u9999\u874c\u86aa"
+      }
     },
     "Poliwhirl": {
-      "codename": "061"
+      "codename": "061",
+      "locale": {
+        "fr": "T\u00eatarte",
+        "de": "Quaputzi",
+        "ko": "\uc288\ub959\ucc59\uc774",
+        "ja": "\u30cb\u30e7\u30ed\u30be",
+        "zh_CN": "\u868a\u9999\u541b",
+        "zh_TW": "\u868a\u9999\u541b"
+      }
     },
     "Poliwrath": {
-      "codename": "062"
+      "codename": "062",
+      "locale": {
+        "fr": "Tartard",
+        "de": "Quappo",
+        "ko": "\uac15\ucc59\uc774",
+        "ja": "\u30cb\u30e7\u30ed\u30dc\u30f3",
+        "zh_CN": "\u868a\u9999\u6cf3\u58eb",
+        "zh_TW": "\u868a\u9999\u6cf3\u58eb"
+      }
     },
     "Abra": {
-      "codename": "063"
+      "codename": "063",
+      "locale": {
+        "fr": "Abra",
+        "de": "Abra",
+        "ko": "\uce90\uc774\uc2dc",
+        "ja": "\u30b1\u30fc\u30b7\u30a3",
+        "zh_CN": "\u51ef\u897f",
+        "zh_TW": "\u51f1\u897f"
+      }
     },
     "Kadabra": {
-      "codename": "064"
+      "codename": "064",
+      "locale": {
+        "fr": "Kadabra",
+        "de": "Kadabra",
+        "ko": "\uc724\uac94\ub77c",
+        "ja": "\u30e6\u30f3\u30b2\u30e9\u30fc",
+        "zh_CN": "\u52c7\u57fa\u62c9",
+        "zh_TW": "\u52c7\u57fa\u62c9"
+      }
     },
     "Alakazam": {
-      "codename": "065"
+      "codename": "065",
+      "locale": {
+        "fr": "Alakazam",
+        "de": "Simsala",
+        "ko": "\ud6c4\ub518",
+        "ja": "\u30d5\u30fc\u30c7\u30a3\u30f3",
+        "zh_CN": "\u80e1\u5730",
+        "zh_TW": "\u80e1\u5730"
+      }
     },
     "Machop": {
-      "codename": "066"
+      "codename": "066",
+      "locale": {
+        "fr": "Machoc",
+        "de": "Machollo",
+        "ko": "\uc54c\ud1b5\ubaac",
+        "ja": "\u30ef\u30f3\u30ea\u30ad\u30fc",
+        "zh_CN": "\u8155\u529b",
+        "zh_TW": "\u8155\u529b"
+      }
     },
     "Machoke": {
-      "codename": "067"
+      "codename": "067",
+      "locale": {
+        "fr": "Machopeur",
+        "de": "Maschock",
+        "ko": "\uadfc\uc721\ubaac",
+        "ja": "\u30b4\u30fc\u30ea\u30ad\u30fc",
+        "zh_CN": "\u8c6a\u529b",
+        "zh_TW": "\u8c6a\u529b"
+      }
     },
     "Machamp": {
-      "codename": "068"
+      "codename": "068",
+      "locale": {
+        "fr": "Mackogneur",
+        "de": "Machomei",
+        "ko": "\uad34\ub825\ubaac",
+        "ja": "\u30ab\u30a4\u30ea\u30ad\u30fc",
+        "zh_CN": "\u602a\u529b",
+        "zh_TW": "\u602a\u529b"
+      }
     },
     "Bellsprout": {
-      "codename": "069"
+      "codename": "069",
+      "locale": {
+        "fr": "Ch\u00e9tiflor",
+        "de": "Knofensa",
+        "ko": "\ubaa8\ub2e4\ud53c",
+        "ja": "\u30de\u30c0\u30c4\u30dc\u30df",
+        "zh_CN": "\u5587\u53ed\u82bd",
+        "zh_TW": "\u5587\u53ed\u82bd"
+      }
     },
     "Weepinbell": {
-      "codename": "070"
+      "codename": "070",
+      "locale": {
+        "fr": "Boustiflor",
+        "de": "Ultrigaria",
+        "ko": "\uc6b0\uce20\ub3d9",
+        "ja": "\u30a6\u30c4\u30c9\u30f3",
+        "zh_CN": "\u53e3\u5446\u82b1",
+        "zh_TW": "\u53e3\u5446\u82b1"
+      }
     },
     "Victreebel": {
-      "codename": "071"
+      "codename": "071",
+      "locale": {
+        "fr": "Empiflor",
+        "de": "Sarzenia",
+        "ko": "\uc6b0\uce20\ubcf4\ud2b8",
+        "ja": "\u30a6\u30c4\u30dc\u30c3\u30c8",
+        "zh_CN": "\u5927\u98df\u82b1",
+        "zh_TW": "\u5927\u98df\u82b1"
+      }
     },
     "Tentacool": {
-      "codename": "072"
+      "codename": "072",
+      "locale": {
+        "fr": "Tentacool",
+        "de": "Tentacha",
+        "ko": "\uc655\ub208\ud574",
+        "ja": "\u30e1\u30ce\u30af\u30e9\u30b2",
+        "zh_CN": "\u739b\u7459\u6c34\u6bcd",
+        "zh_TW": "\u746a\u7459\u6c34\u6bcd"
+      }
     },
     "Tentacruel": {
-      "codename": "073"
+      "codename": "073",
+      "locale": {
+        "fr": "Tentacruel",
+        "de": "Tentoxa",
+        "ko": "\ub3c5\ud30c\ub9ac",
+        "ja": "\u30c9\u30af\u30af\u30e9\u30b2",
+        "zh_CN": "\u6bd2\u523a\u6c34\u6bcd",
+        "zh_TW": "\u6bd2\u523a\u6c34\u6bcd"
+      }
     },
     "Geodude": {
-      "codename": "074"
+      "codename": "074",
+      "locale": {
+        "fr": "Racaillou",
+        "de": "Kleinstein",
+        "ko": "\uaf2c\ub9c8\ub3cc",
+        "ja": "\u30a4\u30b7\u30c4\u30d6\u30c6",
+        "zh_CN": "\u5c0f\u62f3\u77f3",
+        "zh_TW": "\u5c0f\u62f3\u77f3"
+      }
     },
     "Graveler": {
-      "codename": "075"
+      "codename": "075",
+      "locale": {
+        "fr": "Gravalanch",
+        "de": "Georok",
+        "ko": "\ub370\uad6c\ub9ac",
+        "ja": "\u30b4\u30ed\u30fc\u30f3",
+        "zh_CN": "\u9686\u9686\u77f3",
+        "zh_TW": "\u9686\u9686\u77f3"
+      }
     },
     "Golem": {
-      "codename": "076"
+      "codename": "076",
+      "locale": {
+        "fr": "Grolem",
+        "de": "Geowaz",
+        "ko": "\ub531\uad6c\ub9ac",
+        "ja": "\u30b4\u30ed\u30fc\u30cb\u30e3",
+        "zh_CN": "\u9686\u9686\u5ca9",
+        "zh_TW": "\u9686\u9686\u5ca9"
+      }
     },
     "Ponyta": {
-      "codename": "077"
+      "codename": "077",
+      "locale": {
+        "fr": "Ponyta",
+        "de": "Ponita",
+        "ko": "\ud3ec\ub2c8\ud0c0",
+        "ja": "\u30dd\u30cb\u30fc\u30bf",
+        "zh_CN": "\u5c0f\u706b\u9a6c",
+        "zh_TW": "\u5c0f\u706b\u99ac"
+      }
     },
     "Rapidash": {
-      "codename": "078"
+      "codename": "078",
+      "locale": {
+        "fr": "Galopa",
+        "de": "Gallopa",
+        "ko": "\ub0a0\uc329\ub9c8",
+        "ja": "\u30ae\u30e3\u30ed\u30c3\u30d7",
+        "zh_CN": "\u70c8\u7130\u9a6c",
+        "zh_TW": "\u70c8\u7130\u99ac"
+      }
     },
     "Slowpoke": {
-      "codename": "079"
+      "codename": "079",
+      "locale": {
+        "fr": "Ramoloss",
+        "de": "Flegmon",
+        "ko": "\uc57c\ub3c8",
+        "ja": "\u30e4\u30c9\u30f3",
+        "zh_CN": "\u5446\u5446\u517d",
+        "zh_TW": "\u5446\u5446\u7378"
+      }
     },
     "Slowbro": {
-      "codename": "080"
+      "codename": "080",
+      "locale": {
+        "fr": "Flagadoss",
+        "de": "Lahmus",
+        "ko": "\uc57c\ub3c4\ub780",
+        "ja": "\u30e4\u30c9\u30e9\u30f3",
+        "zh_CN": "\u5446\u58f3\u517d",
+        "zh_TW": "\u5446\u6bbc\u7378"
+      }
     },
     "Magnemite": {
-      "codename": "081"
+      "codename": "081",
+      "locale": {
+        "fr": "Magn\u00e9ti",
+        "de": "Magnetilo",
+        "ko": "\ucf54\uc77c",
+        "ja": "\u30b3\u30a4\u30eb",
+        "zh_CN": "\u5c0f\u78c1\u602a",
+        "zh_TW": "\u5c0f\u78c1\u602a"
+      }
     },
     "Magneton": {
-      "codename": "082"
+      "codename": "082",
+      "locale": {
+        "fr": "Magn\u00e9ton",
+        "de": "Magneton",
+        "ko": "\ub808\uc5b4\ucf54\uc77c",
+        "ja": "\u30ec\u30a2\u30b3\u30a4\u30eb",
+        "zh_CN": "\u4e09\u5408\u4e00\u78c1\u602a",
+        "zh_TW": "\u4e09\u5408\u4e00\u78c1\u602a"
+      }
     },
     "Farfetch'd": {
-      "codename": "083"
+      "codename": "083",
+      "locale": {
+        "fr": "Canarticho",
+        "de": "Porenta",
+        "ko": "\ud30c\uc624\ub9ac",
+        "ja": "\u30ab\u30e2\u30cd\u30ae",
+        "zh_CN": "\u5927\u8471\u9e2d",
+        "zh_TW": "\u5927\u8525\u9d28"
+      }
     },
     "Doduo": {
-      "codename": "084"
+      "codename": "084",
+      "locale": {
+        "fr": "Doduo",
+        "de": "Dodu",
+        "ko": "\ub450\ub450",
+        "ja": "\u30c9\u30fc\u30c9\u30fc",
+        "zh_CN": "\u561f\u561f",
+        "zh_TW": "\u561f\u561f"
+      }
     },
     "Dodrio": {
-      "codename": "085"
+      "codename": "085",
+      "locale": {
+        "fr": "Dodrio",
+        "de": "Dodri",
+        "ko": "\ub450\ud2b8\ub9ac\uc624",
+        "ja": "\u30c9\u30fc\u30c9\u30ea\u30aa",
+        "zh_CN": "\u561f\u561f\u5229",
+        "zh_TW": "\u561f\u561f\u5229"
+      }
     },
     "Seel": {
-      "codename": "086"
+      "codename": "086",
+      "locale": {
+        "fr": "Otaria",
+        "de": "Jurob",
+        "ko": "\uc96c\uc96c",
+        "ja": "\u30d1\u30a6\u30ef\u30a6",
+        "zh_CN": "\u5c0f\u6d77\u72ee",
+        "zh_TW": "\u5c0f\u6d77\u7345"
+      }
     },
     "Dewgong": {
-      "codename": "087"
+      "codename": "087",
+      "locale": {
+        "fr": "Lamantine",
+        "de": "Jugong",
+        "ko": "\uc96c\ub808\uace4",
+        "ja": "\u30b8\u30e5\u30b4\u30f3",
+        "zh_CN": "\u767d\u6d77\u72ee",
+        "zh_TW": "\u767d\u6d77\u7345"
+      }
     },
     "Grimer": {
-      "codename": "088"
+      "codename": "088",
+      "locale": {
+        "fr": "Tadmorv",
+        "de": "Sleima",
+        "ko": "\uc9c8\ud37d\uc774",
+        "ja": "\u30d9\u30c8\u30d9\u30bf\u30fc",
+        "zh_CN": "\u81ed\u6ce5",
+        "zh_TW": "\u81ed\u6ce5"
+      }
     },
     "Muk": {
-      "codename": "089"
+      "codename": "089",
+      "locale": {
+        "fr": "Grotadmorv",
+        "de": "Sleimok",
+        "ko": "\uc9c8\ubed0\uae30",
+        "ja": "\u30d9\u30c8\u30d9\u30c8\u30f3",
+        "zh_CN": "\u81ed\u81ed\u6ce5",
+        "zh_TW": "\u81ed\u81ed\u6ce5"
+      }
     },
     "Shellder": {
-      "codename": "090"
+      "codename": "090",
+      "locale": {
+        "fr": "Kokiyas",
+        "de": "Muschas",
+        "ko": "\uc140\ub7ec",
+        "ja": "\u30b7\u30a7\u30eb\u30c0\u30fc",
+        "zh_CN": "\u5927\u820c\u8d1d",
+        "zh_TW": "\u5927\u820c\u8c9d"
+      }
     },
     "Cloyster": {
-      "codename": "091"
+      "codename": "091",
+      "locale": {
+        "fr": "Crustabri",
+        "de": "Austos",
+        "ko": "\ud30c\ub974\uc140",
+        "ja": "\u30d1\u30eb\u30b7\u30a7\u30f3",
+        "zh_CN": "\u523a\u7532\u8d1d",
+        "zh_TW": "\u523a\u7532\u8c9d"
+      }
     },
     "Gastly": {
-      "codename": "092"
+      "codename": "092",
+      "locale": {
+        "fr": "Fantominus",
+        "de": "Nebulak",
+        "ko": "\uace0\uc624\uc2a4",
+        "ja": "\u30b4\u30fc\u30b9",
+        "zh_CN": "\u9b3c\u65af",
+        "zh_TW": "\u9b3c\u65af"
+      }
     },
     "Haunter": {
-      "codename": "093"
+      "codename": "093",
+      "locale": {
+        "fr": "Spectrum",
+        "de": "Alpollo",
+        "ko": "\uace0\uc6b0\uc2a4\ud2b8",
+        "ja": "\u30b4\u30fc\u30b9\u30c8",
+        "zh_CN": "\u9b3c\u65af\u901a",
+        "zh_TW": "\u9b3c\u65af\u901a"
+      }
     },
     "Gengar": {
-      "codename": "094"
+      "codename": "094",
+      "locale": {
+        "fr": "Ectoplasma",
+        "de": "Gengar",
+        "ko": "\ud32c\ud140",
+        "ja": "\u30b2\u30f3\u30ac\u30fc",
+        "zh_CN": "\u803f\u9b3c",
+        "zh_TW": "\u803f\u9b3c"
+      }
     },
     "Onix": {
-      "codename": "095"
+      "codename": "095",
+      "locale": {
+        "fr": "Onix",
+        "de": "Onix",
+        "ko": "\ub871\uc2a4\ud1a4",
+        "ja": "\u30a4\u30ef\u30fc\u30af",
+        "zh_CN": "\u5927\u5ca9\u86c7",
+        "zh_TW": "\u5927\u5ca9\u86c7"
+      }
     },
     "Drowzee": {
-      "codename": "096"
+      "codename": "096",
+      "locale": {
+        "fr": "Soporifik",
+        "de": "Traumato",
+        "ko": "\uc2ac\ub9ac\ud504",
+        "ja": "\u30b9\u30ea\u30fc\u30d7",
+        "zh_CN": "\u50ac\u7720\u8c98",
+        "zh_TW": "\u50ac\u7720\u8c98"
+      }
     },
     "Hypno": {
-      "codename": "097"
+      "codename": "097",
+      "locale": {
+        "fr": "Hypnomade",
+        "de": "Hypno",
+        "ko": "\uc2ac\ub9ac\ud37c",
+        "ja": "\u30b9\u30ea\u30fc\u30d1\u30fc",
+        "zh_CN": "\u5f15\u68a6\u8c98\u4eba",
+        "zh_TW": "\u5f15\u5922\u8c98\u4eba"
+      }
     },
     "Krabby": {
-      "codename": "098"
+      "codename": "098",
+      "locale": {
+        "fr": "Krabby",
+        "de": "Krabby",
+        "ko": "\ud06c\ub7a9",
+        "ja": "\u30af\u30e9\u30d6",
+        "zh_CN": "\u5927\u94b3\u87f9",
+        "zh_TW": "\u5927\u9257\u87f9"
+      }
     },
     "Kingler": {
-      "codename": "099"
+      "codename": "099",
+      "locale": {
+        "fr": "Krabboss",
+        "de": "Kingler",
+        "ko": "\ud0b9\ud06c\ub7a9",
+        "ja": "\u30ad\u30f3\u30b0\u30e9\u30fc",
+        "zh_CN": "\u5de8\u94b3\u87f9",
+        "zh_TW": "\u5de8\u9257\u87f9"
+      }
     },
     "Voltorb": {
-      "codename": "100"
+      "codename": "100",
+      "locale": {
+        "fr": "Voltorbe",
+        "de": "Voltobal",
+        "ko": "\ucc0c\ub9ac\ub9ac\uacf5",
+        "ja": "\u30d3\u30ea\u30ea\u30c0\u30de",
+        "zh_CN": "\u9739\u96f3\u7535\u7403",
+        "zh_TW": "\u9739\u9742\u96fb\u7403"
+      }
     },
     "Electrode": {
-      "codename": "101"
+      "codename": "101",
+      "locale": {
+        "fr": "\u00c9lectrode",
+        "de": "Lektrobal",
+        "ko": "\ubd90\ubcfc",
+        "ja": "\u30de\u30eb\u30de\u30a4\u30f3",
+        "zh_CN": "\u987d\u76ae\u96f7\u5f39",
+        "zh_TW": "\u9811\u76ae\u96f7\u5f48"
+      }
     },
     "Exeggcute": {
-      "codename": "102"
+      "codename": "102",
+      "locale": {
+        "fr": "N\u0153un\u0153uf",
+        "de": "Owei",
+        "ko": "\uc544\ub77c\ub9ac",
+        "ja": "\u30bf\u30de\u30bf\u30de",
+        "zh_CN": "\u86cb\u86cb",
+        "zh_TW": "\u86cb\u86cb"
+      }
     },
     "Exeggutor": {
-      "codename": "103"
+      "codename": "103",
+      "locale": {
+        "fr": "Noadkoko",
+        "de": "Kokowei",
+        "ko": "\ub098\uc2dc",
+        "ja": "\u30ca\u30c3\u30b7\u30fc",
+        "zh_CN": "\u6930\u86cb\u6811",
+        "zh_TW": "\u6930\u86cb\u6a39"
+      }
     },
     "Cubone": {
-      "codename": "104"
+      "codename": "104",
+      "locale": {
+        "fr": "Osselait",
+        "de": "Tragosso",
+        "ko": "\ud0d5\uad6c\ub9ac",
+        "ja": "\u30ab\u30e9\u30ab\u30e9",
+        "zh_CN": "\u5361\u62c9\u5361\u62c9",
+        "zh_TW": "\u5361\u62c9\u5361\u62c9"
+      }
     },
     "Marowak": {
-      "codename": "105"
+      "codename": "105",
+      "locale": {
+        "fr": "Ossatueur",
+        "de": "Knogga",
+        "ko": "\ud145\uad6c\ub9ac",
+        "ja": "\u30ac\u30e9\u30ac\u30e9",
+        "zh_CN": "\u560e\u5566\u560e\u5566",
+        "zh_TW": "\u560e\u5566\u560e\u5566"
+      }
     },
     "Hitmonlee": {
-      "codename": "106"
+      "codename": "106",
+      "locale": {
+        "fr": "Kicklee",
+        "de": "Kicklee",
+        "ko": "\uc2dc\ub77c\uc18c\ubaac",
+        "ja": "\u30b5\u30ef\u30e0\u30e9\u30fc",
+        "zh_CN": "\u98de\u817f\u90ce",
+        "zh_TW": "\u98db\u817f\u90ce"
+      }
     },
     "Hitmonchan": {
-      "codename": "107"
+      "codename": "107",
+      "locale": {
+        "fr": "Tygnon",
+        "de": "Nockchan",
+        "ko": "\ud64d\uc218\ubaac",
+        "ja": "\u30a8\u30d3\u30ef\u30e9\u30fc",
+        "zh_CN": "\u5feb\u62f3\u90ce",
+        "zh_TW": "\u5feb\u62f3\u90ce"
+      }
     },
     "Lickitung": {
-      "codename": "108"
+      "codename": "108",
+      "locale": {
+        "fr": "Excelangue",
+        "de": "Schlurp",
+        "ko": "\ub0b4\ub8e8\ubbf8",
+        "ja": "\u30d9\u30ed\u30ea\u30f3\u30ac",
+        "zh_CN": "\u5927\u820c\u5934",
+        "zh_TW": "\u5927\u820c\u982d"
+      }
     },
     "Koffing": {
-      "codename": "109"
+      "codename": "109",
+      "locale": {
+        "fr": "Smogo",
+        "de": "Smogon",
+        "ko": "\ub610\uac00\uc2a4",
+        "ja": "\u30c9\u30ac\u30fc\u30b9",
+        "zh_CN": "\u74e6\u65af\u5f39",
+        "zh_TW": "\u74e6\u65af\u5f48"
+      }
     },
     "Weezing": {
-      "codename": "110"
+      "codename": "110",
+      "locale": {
+        "fr": "Smogogo",
+        "de": "Smogmog",
+        "ko": "\ub610\ub3c4\uac00\uc2a4",
+        "ja": "\u30de\u30bf\u30c9\u30ac\u30b9",
+        "zh_CN": "\u53cc\u5f39\u74e6\u65af",
+        "zh_TW": "\u96d9\u5f48\u74e6\u65af"
+      }
     },
     "Rhyhorn": {
-      "codename": "111"
+      "codename": "111",
+      "locale": {
+        "fr": "Rhinocorne",
+        "de": "Rihorn",
+        "ko": "\ubfd4\uce74\ub178",
+        "ja": "\u30b5\u30a4\u30db\u30fc\u30f3",
+        "zh_CN": "\u72ec\u89d2\u7280\u725b",
+        "zh_TW": "\u7368\u89d2\u7280\u725b"
+      }
     },
     "Rhydon": {
-      "codename": "112"
+      "codename": "112",
+      "locale": {
+        "fr": "Rhinof\u00e9ros",
+        "de": "Rizeros",
+        "ko": "\ucf54\ubfcc\ub9ac",
+        "ja": "\u30b5\u30a4\u30c9\u30f3",
+        "zh_CN": "\u94bb\u89d2\u7280\u517d",
+        "zh_TW": "\u947d\u89d2\u7280\u7378"
+      }
     },
     "Chansey": {
-      "codename": "113"
+      "codename": "113",
+      "locale": {
+        "fr": "Leveinard",
+        "de": "Chaneira",
+        "ko": "\ub7ed\ud0a4",
+        "ja": "\u30e9\u30c3\u30ad\u30fc",
+        "zh_CN": "\u5409\u5229\u86cb",
+        "zh_TW": "\u5409\u5229\u86cb"
+      }
     },
     "Tangela": {
-      "codename": "114"
+      "codename": "114",
+      "locale": {
+        "fr": "Saquedeneu",
+        "de": "Tangela",
+        "ko": "\ub369\ucfe0\ub9ac",
+        "ja": "\u30e2\u30f3\u30b8\u30e3\u30e9",
+        "zh_CN": "\u8513\u85e4\u602a",
+        "zh_TW": "\u8513\u85e4\u602a"
+      }
     },
     "Kangaskhan": {
-      "codename": "115"
+      "codename": "115",
+      "locale": {
+        "fr": "Kangourex",
+        "de": "Kangama",
+        "ko": "\ucea5\uce74",
+        "ja": "\u30ac\u30eb\u30fc\u30e9",
+        "zh_CN": "\u888b\u517d",
+        "zh_TW": "\u888b\u7378"
+      }
     },
     "Horsea": {
-      "codename": "116"
+      "codename": "116",
+      "locale": {
+        "fr": "Hypotrempe",
+        "de": "Seeper",
+        "ko": "\uc3d8\ub4dc\ub77c",
+        "ja": "\u30bf\u30c3\u30c4\u30fc",
+        "zh_CN": "\u58a8\u6d77\u9a6c",
+        "zh_TW": "\u58a8\u6d77\u99ac"
+      }
     },
     "Seadra": {
-      "codename": "117"
+      "codename": "117",
+      "locale": {
+        "fr": "Hypoc\u00e9an",
+        "de": "Seemon",
+        "ko": "\uc2dc\ub4dc\ub77c",
+        "ja": "\u30b7\u30fc\u30c9\u30e9",
+        "zh_CN": "\u6d77\u523a\u9f99",
+        "zh_TW": "\u6d77\u523a\u9f8d"
+      }
     },
     "Goldeen": {
-      "codename": "118"
+      "codename": "118",
+      "locale": {
+        "fr": "Poissir\u00e8ne",
+        "de": "Goldini",
+        "ko": "\ucf58\uce58",
+        "ja": "\u30c8\u30b5\u30ad\u30f3\u30c8",
+        "zh_CN": "\u89d2\u91d1\u9c7c",
+        "zh_TW": "\u89d2\u91d1\u9b5a"
+      }
     },
     "Seaking": {
-      "codename": "119"
+      "codename": "119",
+      "locale": {
+        "fr": "Poissoroy",
+        "de": "Golking",
+        "ko": "\uc655\ucf58\uce58",
+        "ja": "\u30a2\u30ba\u30de\u30aa\u30a6",
+        "zh_CN": "\u91d1\u9c7c\u738b",
+        "zh_TW": "\u91d1\u9b5a\u738b"
+      }
     },
     "Staryu": {
-      "codename": "120"
+      "codename": "120",
+      "locale": {
+        "fr": "Stari",
+        "de": "Sterndu",
+        "ko": "\ubcc4\uac00\uc0ac\ub9ac",
+        "ja": "\u30d2\u30c8\u30c7\u30de\u30f3",
+        "zh_CN": "\u6d77\u661f\u661f",
+        "zh_TW": "\u6d77\u661f\u661f"
+      }
     },
     "Starmie": {
-      "codename": "121"
+      "codename": "121",
+      "locale": {
+        "fr": "Staross",
+        "de": "Starmie",
+        "ko": "\uc544\ucfe0\uc2a4\ud0c0",
+        "ja": "\u30b9\u30bf\u30fc\u30df\u30fc",
+        "zh_CN": "\u5b9d\u77f3\u6d77\u661f",
+        "zh_TW": "\u5bf6\u77f3\u6d77\u661f"
+      }
     },
     "Mr. Mime": {
-      "codename": "122"
+      "codename": "122",
+      "locale": {
+        "fr": "M. Mime",
+        "de": "Pantimos",
+        "ko": "\ub9c8\uc784\ub9e8",
+        "ja": "\u30d0\u30ea\u30e4\u30fc\u30c9",
+        "zh_CN": "\u9b54\u5899\u4eba\u5076",
+        "zh_TW": "\u9b54\u7246\u4eba\u5076"
+      }
     },
     "Scyther": {
-      "codename": "123"
+      "codename": "123",
+      "locale": {
+        "fr": "Ins\u00e9cateur",
+        "de": "Sichlor",
+        "ko": "\uc2a4\ub77c\ud06c",
+        "ja": "\u30b9\u30c8\u30e9\u30a4\u30af",
+        "zh_CN": "\u98de\u5929\u87b3\u8782",
+        "zh_TW": "\u98db\u5929\u87b3\u8782"
+      }
     },
     "Jynx": {
-      "codename": "124"
+      "codename": "124",
+      "locale": {
+        "fr": "Lippoutou",
+        "de": "Rossana",
+        "ko": "\ub8e8\uc8fc\ub77c",
+        "ja": "\u30eb\u30fc\u30b8\u30e5\u30e9",
+        "zh_CN": "\u8ff7\u5507\u59d0",
+        "zh_TW": "\u8ff7\u5507\u59d0"
+      }
     },
     "Electabuzz": {
-      "codename": "125"
+      "codename": "125",
+      "locale": {
+        "fr": "\u00c9lektek",
+        "de": "Elektek",
+        "ko": "\uc5d0\ub808\ube0c",
+        "ja": "\u30a8\u30ec\u30d6\u30fc",
+        "zh_CN": "\u7535\u51fb\u517d",
+        "zh_TW": "\u96fb\u64ca\u7378"
+      }
     },
     "Magmar": {
-      "codename": "126"
+      "codename": "126",
+      "locale": {
+        "fr": "Magmar",
+        "de": "Magmar",
+        "ko": "\ub9c8\uadf8\ub9c8",
+        "ja": "\u30d6\u30fc\u30d0\u30fc",
+        "zh_CN": "\u9e2d\u5634\u706b\u517d",
+        "zh_TW": "\u9d28\u5634\u706b\u7378"
+      }
     },
     "Pinsir": {
-      "codename": "127"
+      "codename": "127",
+      "locale": {
+        "fr": "Scarabrute",
+        "de": "Pinsir",
+        "ko": "\uc058\uc0ac\uc774\uc800",
+        "ja": "\u30ab\u30a4\u30ed\u30b9",
+        "zh_CN": "\u51ef\u7f57\u65af",
+        "zh_TW": "\u51f1\u7f85\u65af"
+      }
     },
     "Tauros": {
-      "codename": "128"
+      "codename": "128",
+      "locale": {
+        "fr": "Tauros",
+        "de": "Tauros",
+        "ko": "\ucf04\ud0c0\ub85c\uc2a4",
+        "ja": "\u30b1\u30f3\u30bf\u30ed\u30b9",
+        "zh_CN": "\u80af\u6cf0\u7f57",
+        "zh_TW": "\u80af\u6cf0\u7f85"
+      }
     },
     "Magikarp": {
-      "codename": "129"
+      "codename": "129",
+      "locale": {
+        "fr": "Magicarpe",
+        "de": "Karpador",
+        "ko": "\uc789\uc5b4\ud0b9",
+        "ja": "\u30b3\u30a4\u30ad\u30f3\u30b0",
+        "zh_CN": "\u9ca4\u9c7c\u738b",
+        "zh_TW": "\u9bc9\u9b5a\u738b"
+      }
     },
     "Gyarados": {
-      "codename": "130"
+      "codename": "130",
+      "locale": {
+        "fr": "L\u00e9viator",
+        "de": "Garados",
+        "ko": "\uac38\ub77c\ub3c4\uc2a4",
+        "ja": "\u30ae\u30e3\u30e9\u30c9\u30b9",
+        "zh_CN": "\u66b4\u9ca4\u9f99",
+        "zh_TW": "\u66b4\u9bc9\u9f8d"
+      }
     },
     "Lapras": {
-      "codename": "131"
+      "codename": "131",
+      "locale": {
+        "fr": "Lokhlass",
+        "de": "Lapras",
+        "ko": "\ub77c\ud504\ub77c\uc2a4",
+        "ja": "\u30e9\u30d7\u30e9\u30b9",
+        "zh_CN": "\u62c9\u666e\u62c9\u65af",
+        "zh_TW": "\u62c9\u666e\u62c9\u65af"
+      }
     },
     "Ditto": {
-      "codename": "132"
+      "codename": "132",
+      "locale": {
+        "fr": "M\u00e9tamorph",
+        "de": "Ditto",
+        "ko": "\uba54\ud0c0\ubabd",
+        "ja": "\u30e1\u30bf\u30e2\u30f3",
+        "zh_CN": "\u767e\u53d8\u602a",
+        "zh_TW": "\u767e\u8b8a\u602a"
+      }
     },
     "Eevee": {
-      "codename": "133"
+      "codename": "133",
+      "locale": {
+        "fr": "\u00c9voli",
+        "de": "Evoli",
+        "ko": "\uc774\ube0c\uc774",
+        "ja": "\u30a4\u30fc\u30d6\u30a4",
+        "zh_CN": "\u4f0a\u5e03",
+        "zh_TW": "\u4f0a\u5e03"
+      }
     },
     "Vaporeon": {
-      "codename": "134"
+      "codename": "134",
+      "locale": {
+        "fr": "Aquali",
+        "de": "Aquana",
+        "ko": "\uc0e4\ubbf8\ub4dc",
+        "ja": "\u30b7\u30e3\u30ef\u30fc\u30ba",
+        "zh_CN": "\u6c34\u4f0a\u5e03",
+        "zh_TW": "\u6c34\u4f0a\u5e03"
+      }
     },
     "Jolteon": {
-      "codename": "135"
+      "codename": "135",
+      "locale": {
+        "fr": "Voltali",
+        "de": "Blitza",
+        "ko": "\uc96c\ud53c\uc36c\ub354",
+        "ja": "\u30b5\u30f3\u30c0\u30fc\u30b9",
+        "zh_CN": "\u96f7\u4f0a\u5e03",
+        "zh_TW": "\u96f7\u4f0a\u5e03"
+      }
     },
     "Flareon": {
-      "codename": "136"
+      "codename": "136",
+      "locale": {
+        "fr": "Pyroli",
+        "de": "Flamara",
+        "ko": "\ubd80\uc2a4\ud130",
+        "ja": "\u30d6\u30fc\u30b9\u30bf\u30fc",
+        "zh_CN": "\u706b\u4f0a\u5e03",
+        "zh_TW": "\u706b\u4f0a\u5e03"
+      }
     },
     "Porygon": {
-      "codename": "137"
+      "codename": "137",
+      "locale": {
+        "fr": "Porygon",
+        "de": "Porygon",
+        "ko": "\ud3f4\ub9ac\uace4",
+        "ja": "\u30dd\u30ea\u30b4\u30f3",
+        "zh_CN": "\u591a\u8fb9\u517d",
+        "zh_TW": "\u591a\u908a\u7378"
+      }
     },
     "Omanyte": {
-      "codename": "138"
+      "codename": "138",
+      "locale": {
+        "fr": "Amonita",
+        "de": "Amonitas",
+        "ko": "\uc554\ub098\uc774\ud2b8",
+        "ja": "\u30aa\u30e0\u30ca\u30a4\u30c8",
+        "zh_CN": "\u83ca\u77f3\u517d",
+        "zh_TW": "\u83ca\u77f3\u7378"
+      }
     },
     "Omastar": {
-      "codename": "139"
+      "codename": "139",
+      "locale": {
+        "fr": "Amonistar",
+        "de": "Amoroso",
+        "ko": "\uc554\uc2a4\ud0c0",
+        "ja": "\u30aa\u30e0\u30b9\u30bf\u30fc",
+        "zh_CN": "\u591a\u523a\u83ca\u77f3\u517d",
+        "zh_TW": "\u591a\u523a\u83ca\u77f3\u7378"
+      }
     },
     "Kabuto": {
-      "codename": "140"
+      "codename": "140",
+      "locale": {
+        "fr": "Kabuto",
+        "de": "Kabuto",
+        "ko": "\ud22c\uad6c",
+        "ja": "\u30ab\u30d6\u30c8",
+        "zh_CN": "\u5316\u77f3\u76d4",
+        "zh_TW": "\u5316\u77f3\u76d4"
+      }
     },
     "Kabutops": {
-      "codename": "141"
+      "codename": "141",
+      "locale": {
+        "fr": "Kabutops",
+        "de": "Kabutops",
+        "ko": "\ud22c\uad6c\ud478\uc2a4",
+        "ja": "\u30ab\u30d6\u30c8\u30d7\u30b9",
+        "zh_CN": "\u9570\u5200\u76d4",
+        "zh_TW": "\u942e\u5200\u76d4"
+      }
     },
     "Aerodactyl": {
-      "codename": "142"
+      "codename": "142",
+      "locale": {
+        "fr": "Pt\u00e9ra",
+        "de": "Aerodactyl",
+        "ko": "\ud504\ud14c\ub77c",
+        "ja": "\u30d7\u30c6\u30e9",
+        "zh_CN": "\u5316\u77f3\u7ffc\u9f99",
+        "zh_TW": "\u5316\u77f3\u7ffc\u9f8d"
+      }
     },
     "Snorlax": {
-      "codename": "143"
+      "codename": "143",
+      "locale": {
+        "fr": "Ronflex",
+        "de": "Relaxo",
+        "ko": "\uc7a0\ub9cc\ubcf4",
+        "ja": "\u30ab\u30d3\u30b4\u30f3",
+        "zh_CN": "\u5361\u6bd4\u517d",
+        "zh_TW": "\u5361\u6bd4\u7378"
+      }
     },
     "Articuno": {
-      "codename": "144"
+      "codename": "144",
+      "locale": {
+        "fr": "Artikodin",
+        "de": "Arktos",
+        "ko": "\ud504\ub9ac\uc838",
+        "ja": "\u30d5\u30ea\u30fc\u30b6\u30fc",
+        "zh_CN": "\u6025\u51bb\u9e1f",
+        "zh_TW": "\u6025\u51cd\u9ce5"
+      }
     },
     "Zapdos": {
-      "codename": "145"
+      "codename": "145",
+      "locale": {
+        "fr": "\u00c9lecthor",
+        "de": "Zapdos",
+        "ko": "\uc36c\ub354",
+        "ja": "\u30b5\u30f3\u30c0\u30fc",
+        "zh_CN": "\u95ea\u7535\u9e1f",
+        "zh_TW": "\u9583\u96fb\u9ce5"
+      }
     },
     "Moltres": {
-      "codename": "146"
+      "codename": "146",
+      "locale": {
+        "fr": "Sulfura",
+        "de": "Lavados",
+        "ko": "\ud30c\uc774\uc5b4",
+        "ja": "\u30d5\u30a1\u30a4\u30e4\u30fc",
+        "zh_CN": "\u706b\u7130\u9e1f",
+        "zh_TW": "\u706b\u7130\u9ce5"
+      }
     },
     "Dratini": {
-      "codename": "147"
+      "codename": "147",
+      "locale": {
+        "fr": "Minidraco",
+        "de": "Dratini",
+        "ko": "\ubbf8\ub1fd",
+        "ja": "\u30df\u30cb\u30ea\u30e5\u30a6",
+        "zh_CN": "\u8ff7\u4f60\u9f99",
+        "zh_TW": "\u8ff7\u4f60\u9f8d"
+      }
     },
     "Dragonair": {
-      "codename": "148"
+      "codename": "148",
+      "locale": {
+        "fr": "Draco",
+        "de": "Dragonir",
+        "ko": "\uc2e0\ub1fd",
+        "ja": "\u30cf\u30af\u30ea\u30e5\u30fc",
+        "zh_CN": "\u54c8\u514b\u9f99",
+        "zh_TW": "\u54c8\u514b\u9f8d"
+      }
     },
     "Dragonite": {
-      "codename": "149"
+      "codename": "149",
+      "locale": {
+        "fr": "Dracolosse",
+        "de": "Dragoran",
+        "ko": "\ub9dd\ub098\ub1fd",
+        "ja": "\u30ab\u30a4\u30ea\u30e5\u30fc",
+        "zh_CN": "\u5feb\u9f99",
+        "zh_TW": "\u5feb\u9f8d"
+      }
     },
     "Mewtwo": {
-      "codename": "150"
+      "codename": "150",
+      "locale": {
+        "fr": "Mewtwo",
+        "de": "Mewtu",
+        "ko": "\ubba4\uce20",
+        "ja": "\u30df\u30e5\u30a6\u30c4\u30fc",
+        "zh_CN": "\u8d85\u68a6",
+        "zh_TW": "\u8d85\u5922"
+      }
     },
     "Mew": {
-      "codename": "151"
+      "codename": "151",
+      "locale": {
+        "fr": "Mew",
+        "de": "Mew",
+        "ko": "\ubba4",
+        "ja": "\u30df\u30e5\u30a6",
+        "zh_CN": "\u68a6\u5e7b",
+        "zh_TW": "\u5922\u5e7b"
+      }
     },
     "Chikorita": {
-      "codename": "152"
+      "codename": "152",
+      "locale": {
+        "fr": "Germignon",
+        "de": "Endivie",
+        "ko": "\uce58\ucf54\ub9ac\ud0c0",
+        "ja": "\u30c1\u30b3\u30ea\u30fc\u30bf",
+        "zh_CN": "\u83ca\u8349\u53f6",
+        "zh_TW": "\u83ca\u8349\u8449"
+      }
     },
     "Bayleef": {
-      "codename": "153"
+      "codename": "153",
+      "locale": {
+        "fr": "Macronium",
+        "de": "Lorblatt",
+        "ko": "\ubca0\uc774\ub9ac\ud504",
+        "ja": "\u30d9\u30a4\u30ea\u30fc\u30d5",
+        "zh_CN": "\u6708\u6842\u53f6",
+        "zh_TW": "\u6708\u6842\u8449"
+      }
     },
     "Meganium": {
-      "codename": "154"
+      "codename": "154",
+      "locale": {
+        "fr": "M\u00e9ganium",
+        "de": "Meganie",
+        "ko": "\uba54\uac00\ub2c8\uc6c0",
+        "ja": "\u30e1\u30ac\u30cb\u30a6\u30e0",
+        "zh_CN": "\u5927\u83ca\u82b1",
+        "zh_TW": "\u5927\u83ca\u82b1"
+      }
     },
     "Cyndaquil": {
-      "codename": "155"
+      "codename": "155",
+      "locale": {
+        "fr": "H\u00e9ricendre",
+        "de": "Feurigel",
+        "ko": "\ube0c\ucf00\uc778",
+        "ja": "\u30d2\u30ce\u30a2\u30e9\u30b7",
+        "zh_CN": "\u706b\u7403\u9f20",
+        "zh_TW": "\u706b\u7403\u9f20"
+      }
     },
     "Quilava": {
-      "codename": "156"
+      "codename": "156",
+      "locale": {
+        "fr": "Feurisson",
+        "de": "Igelavar",
+        "ko": "\ub9c8\uadf8\ucf00\uc778",
+        "ja": "\u30de\u30b0\u30de\u30e9\u30b7",
+        "zh_CN": "\u706b\u5ca9\u9f20",
+        "zh_TW": "\u706b\u5ca9\u9f20"
+      }
     },
     "Typhlosion": {
-      "codename": "157"
+      "codename": "157",
+      "locale": {
+        "fr": "Typhlosion",
+        "de": "Tornupto",
+        "ko": "\ube14\ub808\uc774\ubc94",
+        "ja": "\u30d0\u30af\u30d5\u30fc\u30f3",
+        "zh_CN": "\u706b\u66b4\u517d",
+        "zh_TW": "\u706b\u66b4\u7378"
+      }
     },
     "Totodile": {
-      "codename": "158"
+      "codename": "158",
+      "locale": {
+        "fr": "Kaiminus",
+        "de": "Karnimani",
+        "ko": "\ub9ac\uc544\ucf54",
+        "ja": "\u30ef\u30cb\u30ce\u30b3",
+        "zh_CN": "\u5c0f\u952f\u9cc4",
+        "zh_TW": "\u5c0f\u92f8\u9c77"
+      }
     },
     "Croconaw": {
-      "codename": "159"
+      "codename": "159",
+      "locale": {
+        "fr": "Crocrodil",
+        "de": "Tyracroc",
+        "ko": "\uc5d8\ub9ac\uac8c\uc774",
+        "ja": "\u30a2\u30ea\u30b2\u30a4\u30c4",
+        "zh_CN": "\u84dd\u9cc4",
+        "zh_TW": "\u85cd\u9c77"
+      }
     },
     "Feraligatr": {
-      "codename": "160"
+      "codename": "160",
+      "locale": {
+        "fr": "Aligatueur",
+        "de": "Impergator",
+        "ko": "\uc7a5\ud06c\ub85c\ub2e4\uc77c",
+        "ja": "\u30aa\u30fc\u30c0\u30a4\u30eb",
+        "zh_CN": "\u5927\u529b\u9cc4",
+        "zh_TW": "\u5927\u529b\u9c77"
+      }
     },
     "Sentret": {
-      "codename": "161"
+      "codename": "161",
+      "locale": {
+        "fr": "Fouinette",
+        "de": "Wiesor",
+        "ko": "\uaf2c\ub9ac\uc120",
+        "ja": "\u30aa\u30bf\u30c1",
+        "zh_CN": "\u5c3e\u7acb",
+        "zh_TW": "\u5c3e\u7acb"
+      }
     },
     "Furret": {
-      "codename": "162"
+      "codename": "162",
+      "locale": {
+        "fr": "Fouinar",
+        "de": "Wiesenior",
+        "ko": "\ub2e4\uaf2c\ub9ac",
+        "ja": "\u30aa\u30aa\u30bf\u30c1",
+        "zh_CN": "\u5927\u5c3e\u7acb",
+        "zh_TW": "\u5927\u5c3e\u7acb"
+      }
     },
     "Hoothoot": {
-      "codename": "163"
+      "codename": "163",
+      "locale": {
+        "fr": "Hoothoot",
+        "de": "Hoothoot",
+        "ko": "\ubd80\uc6b0\ubd80",
+        "ja": "\u30db\u30fc\u30db\u30fc",
+        "zh_CN": "\u5495\u5495",
+        "zh_TW": "\u5495\u5495"
+      }
     },
     "Noctowl": {
-      "codename": "164"
+      "codename": "164",
+      "locale": {
+        "fr": "Noarfang",
+        "de": "Noctuh",
+        "ko": "\uc57c\ubd80\uc5c9",
+        "ja": "\u30e8\u30eb\u30ce\u30ba\u30af",
+        "zh_CN": "\u732b\u5934\u591c\u9e70",
+        "zh_TW": "\u8c93\u982d\u591c\u9df9"
+      }
     },
     "Ledyba": {
-      "codename": "165"
+      "codename": "165",
+      "locale": {
+        "fr": "Coxy",
+        "de": "Ledyba",
+        "ko": "\ub808\ub514\ubc14",
+        "ja": "\u30ec\u30c7\u30a3\u30d0",
+        "zh_CN": "\u82ad\u74e2\u866b",
+        "zh_TW": "\u82ad\u74e2\u87f2"
+      }
     },
     "Ledian": {
-      "codename": "166"
+      "codename": "166",
+      "locale": {
+        "fr": "Coxyclaque",
+        "de": "Ledian",
+        "ko": "\ub808\ub514\uc548",
+        "ja": "\u30ec\u30c7\u30a3\u30a2\u30f3",
+        "zh_CN": "\u5b89\u74e2\u866b",
+        "zh_TW": "\u5b89\u74e2\u87f2"
+      }
     },
     "Spinarak": {
-      "codename": "167"
+      "codename": "167",
+      "locale": {
+        "fr": "Mimigal",
+        "de": "Webarak",
+        "ko": "\ud398\uc774\uac80",
+        "ja": "\u30a4\u30c8\u30de\u30eb",
+        "zh_CN": "\u7ebf\u7403",
+        "zh_TW": "\u7dda\u7403"
+      }
     },
     "Ariados": {
-      "codename": "168"
+      "codename": "168",
+      "locale": {
+        "fr": "Migalos",
+        "de": "Ariados",
+        "ko": "\uc544\ub9ac\uc544\ub3c4\uc2a4",
+        "ja": "\u30a2\u30ea\u30a2\u30c9\u30b9",
+        "zh_CN": "\u963f\u5229\u591a\u65af",
+        "zh_TW": "\u963f\u5229\u591a\u65af"
+      }
     },
     "Crobat": {
-      "codename": "169"
+      "codename": "169",
+      "locale": {
+        "fr": "Nostenfer",
+        "de": "Iksbat",
+        "ko": "\ud06c\ub85c\ubc43",
+        "ja": "\u30af\u30ed\u30d0\u30c3\u30c8",
+        "zh_CN": "\u53c9\u5b57\u8760",
+        "zh_TW": "\u53c9\u5b57\u8760"
+      }
     },
     "Chinchou": {
-      "codename": "170"
+      "codename": "170",
+      "locale": {
+        "fr": "Loupio",
+        "de": "Lampi",
+        "ko": "\ucd08\ub77c\uae30",
+        "ja": "\u30c1\u30e7\u30f3\u30c1\u30fc",
+        "zh_CN": "\u706f\u7b3c\u9c7c",
+        "zh_TW": "\u71c8\u7c60\u9b5a"
+      }
     },
     "Lanturn": {
-      "codename": "171"
+      "codename": "171",
+      "locale": {
+        "fr": "Lanturn",
+        "de": "Lanturn",
+        "ko": "\ub79c\ud134",
+        "ja": "\u30e9\u30f3\u30bf\u30fc\u30f3",
+        "zh_CN": "\u7535\u706f\u602a",
+        "zh_TW": "\u96fb\u71c8\u602a"
+      }
     },
     "Pichu": {
-      "codename": "172"
+      "codename": "172",
+      "locale": {
+        "fr": "Pichu",
+        "de": "Pichu",
+        "ko": "\ud53c\uce04",
+        "ja": "\u30d4\u30c1\u30e5\u30fc",
+        "zh_CN": "\u76ae\u4e18",
+        "zh_TW": "\u76ae\u4e18"
+      }
     },
     "Cleffa": {
-      "codename": "173"
+      "codename": "173",
+      "locale": {
+        "fr": "M\u00e9lo",
+        "de": "Pii",
+        "ko": "\uc090",
+        "ja": "\u30d4\u30a3",
+        "zh_CN": "\u76ae\u5b9d\u5b9d",
+        "zh_TW": "\u76ae\u5bf6\u5bf6"
+      }
     },
     "Igglybuff": {
-      "codename": "174"
+      "codename": "174",
+      "locale": {
+        "fr": "Toudoudou",
+        "de": "Fluffeluff",
+        "ko": "\ud478\ud478\ub9b0",
+        "ja": "\u30d7\u30d7\u30ea\u30f3",
+        "zh_CN": "\u5b9d\u5b9d\u4e01",
+        "zh_TW": "\u5bf6\u5bf6\u4e01"
+      }
     },
     "Togepi": {
-      "codename": "175"
+      "codename": "175",
+      "locale": {
+        "fr": "Togepi",
+        "de": "Togepi",
+        "ko": "\ud1a0\uac8c\ud53c",
+        "ja": "\u30c8\u30b2\u30d4\u30fc",
+        "zh_CN": "\u6ce2\u514b\u6bd4",
+        "zh_TW": "\u6ce2\u514b\u6bd4"
+      }
     },
     "Togetic": {
-      "codename": "176"
+      "codename": "176",
+      "locale": {
+        "fr": "Togetic",
+        "de": "Togetic",
+        "ko": "\ud1a0\uac8c\ud2f1",
+        "ja": "\u30c8\u30b2\u30c1\u30c3\u30af",
+        "zh_CN": "\u6ce2\u514b\u57fa\u53e4",
+        "zh_TW": "\u6ce2\u514b\u57fa\u53e4"
+      }
     },
     "Natu": {
-      "codename": "177"
+      "codename": "177",
+      "locale": {
+        "fr": "Natu",
+        "de": "Natu",
+        "ko": "\ub124\uc774\ud2f0",
+        "ja": "\u30cd\u30a4\u30c6\u30a3",
+        "zh_CN": "\u5929\u7136\u96c0",
+        "zh_TW": "\u5929\u7136\u96c0"
+      }
     },
     "Xatu": {
-      "codename": "178"
+      "codename": "178",
+      "locale": {
+        "fr": "Xatu",
+        "de": "Xatu",
+        "ko": "\ub124\uc774\ud2f0\uc624",
+        "ja": "\u30cd\u30a4\u30c6\u30a3\u30aa",
+        "zh_CN": "\u5929\u7136\u9e1f",
+        "zh_TW": "\u5929\u7136\u9ce5"
+      }
     },
     "Mareep": {
-      "codename": "179"
+      "codename": "179",
+      "locale": {
+        "fr": "Wattouat",
+        "de": "Voltilamm",
+        "ko": "\uba54\ub9ac\ud504",
+        "ja": "\u30e1\u30ea\u30fc\u30d7",
+        "zh_CN": "\u54a9\u5229\u7f8a",
+        "zh_TW": "\u54a9\u5229\u7f8a"
+      }
     },
     "Flaaffy": {
-      "codename": "180"
+      "codename": "180",
+      "locale": {
+        "fr": "Lainergie",
+        "de": "Waaty",
+        "ko": "\ubcf4\uc1a1\uc1a1",
+        "ja": "\u30e2\u30b3\u30b3",
+        "zh_CN": "\u7ef5\u7ef5",
+        "zh_TW": "\u7dbf\u7dbf"
+      }
     },
     "Ampharos": {
-      "codename": "181"
+      "codename": "181",
+      "locale": {
+        "fr": "Pharamp",
+        "de": "Ampharos",
+        "ko": "\uc804\ub8e1",
+        "ja": "\u30c7\u30f3\u30ea\u30e5\u30a6",
+        "zh_CN": "\u7535\u9f99",
+        "zh_TW": "\u96fb\u9f8d"
+      }
     },
     "Bellossom": {
-      "codename": "182"
+      "codename": "182",
+      "locale": {
+        "fr": "Joliflor",
+        "de": "Blubella",
+        "ko": "\uc544\ub974\ucf54",
+        "ja": "\u30ad\u30ec\u30a4\u30cf\u30ca",
+        "zh_CN": "\u7f8e\u4e3d\u82b1",
+        "zh_TW": "\u7f8e\u9e97\u82b1"
+      }
     },
     "Marill": {
-      "codename": "183"
+      "codename": "183",
+      "locale": {
+        "fr": "Marill",
+        "de": "Marill",
+        "ko": "\ub9c8\ub9b4",
+        "ja": "\u30de\u30ea\u30eb",
+        "zh_CN": "\u739b\u529b\u9732",
+        "zh_TW": "\u746a\u529b\u9732"
+      }
     },
     "Azumarill": {
-      "codename": "184"
+      "codename": "184",
+      "locale": {
+        "fr": "Azumarill",
+        "de": "Azumarill",
+        "ko": "\ub9c8\ub9b4\ub9ac",
+        "ja": "\u30de\u30ea\u30eb\u30ea",
+        "zh_CN": "\u739b\u529b\u9732\u4e3d",
+        "zh_TW": "\u746a\u529b\u9732\u9e97"
+      }
     },
     "Sudowoodo": {
-      "codename": "185"
+      "codename": "185",
+      "locale": {
+        "fr": "Simularbre",
+        "de": "Mogelbaum",
+        "ko": "\uaf2c\uc9c0\ubaa8",
+        "ja": "\u30a6\u30bd\u30c3\u30ad\u30fc",
+        "zh_CN": "\u6811\u624d\u602a",
+        "zh_TW": "\u6a39\u624d\u602a"
+      }
     },
     "Politoed": {
-      "codename": "186"
+      "codename": "186",
+      "locale": {
+        "fr": "Tarpaud",
+        "de": "Quaxo",
+        "ko": "\uc655\uad6c\ub9ac",
+        "ja": "\u30cb\u30e7\u30ed\u30c8\u30ce",
+        "zh_CN": "\u868a\u9999\u86d9\u7687",
+        "zh_TW": "\u868a\u9999\u86d9\u7687"
+      }
     },
     "Hoppip": {
-      "codename": "187"
+      "codename": "187",
+      "locale": {
+        "fr": "Granivol",
+        "de": "Hoppspross",
+        "ko": "\ud1b5\ud1b5\ucf54",
+        "ja": "\u30cf\u30cd\u30c3\u30b3",
+        "zh_CN": "\u6bfd\u5b50\u8349",
+        "zh_TW": "\u6bfd\u5b50\u8349"
+      }
     },
     "Skiploom": {
-      "codename": "188"
+      "codename": "188",
+      "locale": {
+        "fr": "Floravol",
+        "de": "Hubelupf",
+        "ko": "\ub450\ucf54",
+        "ja": "\u30dd\u30dd\u30c3\u30b3",
+        "zh_CN": "\u6bfd\u5b50\u82b1",
+        "zh_TW": "\u6bfd\u5b50\u82b1"
+      }
     },
     "Jumpluff": {
-      "codename": "189"
+      "codename": "189",
+      "locale": {
+        "fr": "Cotovol",
+        "de": "Papungha",
+        "ko": "\uc19c\uc19c\ucf54",
+        "ja": "\u30ef\u30bf\u30c3\u30b3",
+        "zh_CN": "\u6bfd\u5b50\u7ef5",
+        "zh_TW": "\u6bfd\u5b50\u7dbf"
+      }
     },
     "Aipom": {
-      "codename": "190"
+      "codename": "190",
+      "locale": {
+        "fr": "Capumain",
+        "de": "Griffel",
+        "ko": "\uc5d0\uc774\ud31c",
+        "ja": "\u30a8\u30a4\u30d1\u30e0",
+        "zh_CN": "\u957f\u5c3e\u602a\u624b",
+        "zh_TW": "\u9577\u5c3e\u602a\u624b"
+      }
     },
     "Sunkern": {
-      "codename": "191"
+      "codename": "191",
+      "locale": {
+        "fr": "Tournegrin",
+        "de": "Sonnkern",
+        "ko": "\ud574\ub108\uce20",
+        "ja": "\u30d2\u30de\u30ca\u30c3\u30c4",
+        "zh_CN": "\u5411\u65e5\u79cd\u5b50",
+        "zh_TW": "\u5411\u65e5\u7a2e\u5b50"
+      }
     },
     "Sunflora": {
-      "codename": "192"
+      "codename": "192",
+      "locale": {
+        "fr": "H\u00e9liatronc",
+        "de": "Sonnflora",
+        "ko": "\ud574\ub8e8\ubbf8",
+        "ja": "\u30ad\u30de\u30ef\u30ea",
+        "zh_CN": "\u5411\u65e5\u82b1\u602a",
+        "zh_TW": "\u5411\u65e5\u82b1\u602a"
+      }
     },
     "Yanma": {
-      "codename": "193"
+      "codename": "193",
+      "locale": {
+        "fr": "Yanma",
+        "de": "Yanma",
+        "ko": "\uc655\uc790\ub9ac",
+        "ja": "\u30e4\u30f3\u30e4\u30f3\u30de",
+        "zh_CN": "\u9633\u9633\u739b",
+        "zh_TW": "\u967d\u967d\u746a"
+      }
     },
     "Wooper": {
-      "codename": "194"
+      "codename": "194",
+      "locale": {
+        "fr": "Axoloto",
+        "de": "Felino",
+        "ko": "\uc6b0\ud30c",
+        "ja": "\u30a6\u30d1\u30fc",
+        "zh_CN": "\u4e4c\u6ce2",
+        "zh_TW": "\u70cf\u6ce2"
+      }
     },
     "Quagsire": {
-      "codename": "195"
+      "codename": "195",
+      "locale": {
+        "fr": "Maraiste",
+        "de": "Morlord",
+        "ko": "\ub204\uc624",
+        "ja": "\u30cc\u30aa\u30fc",
+        "zh_CN": "\u6cbc\u738b",
+        "zh_TW": "\u6cbc\u738b"
+      }
     },
     "Espeon": {
-      "codename": "196"
+      "codename": "196",
+      "locale": {
+        "fr": "Mentali",
+        "de": "Psiana",
+        "ko": "\uc5d0\ube0c\uc774",
+        "ja": "\u30a8\u30fc\u30d5\u30a3",
+        "zh_CN": "\u592a\u9633\u7cbe\u7075",
+        "zh_TW": "\u592a\u967d\u7cbe\u9748"
+      }
     },
     "Umbreon": {
-      "codename": "197"
+      "codename": "197",
+      "locale": {
+        "fr": "Noctali",
+        "de": "Nachtara",
+        "ko": "\ube14\ub798\ud0a4",
+        "ja": "\u30d6\u30e9\u30c3\u30ad\u30fc",
+        "zh_CN": "\u6708\u7cbe\u7075",
+        "zh_TW": "\u6708\u7cbe\u9748"
+      }
     },
     "Murkrow": {
-      "codename": "198"
+      "codename": "198",
+      "locale": {
+        "fr": "Corn\u00e8bre",
+        "de": "Kramurx",
+        "ko": "\ub2c8\ub85c\uc6b0",
+        "ja": "\u30e4\u30df\u30ab\u30e9\u30b9",
+        "zh_CN": "\u9ed1\u6697\u9e26",
+        "zh_TW": "\u9ed1\u6697\u9d09"
+      }
     },
     "Slowking": {
-      "codename": "199"
+      "codename": "199",
+      "locale": {
+        "fr": "Roigada",
+        "de": "Laschoking",
+        "ko": "\uc57c\ub3c4\ud0b9",
+        "ja": "\u30e4\u30c9\u30ad\u30f3\u30b0",
+        "zh_CN": "\u6cb3\u9a6c\u738b",
+        "zh_TW": "\u6cb3\u99ac\u738b"
+      }
     },
     "Misdreavus": {
-      "codename": "200"
+      "codename": "200",
+      "locale": {
+        "fr": "Feufor\u00eave",
+        "de": "Traunfugil",
+        "ko": "\ubb34\uc6b0\ub9c8",
+        "ja": "\u30e0\u30a6\u30de",
+        "zh_CN": "\u68a6\u5996",
+        "zh_TW": "\u5922\u5996"
+      }
     },
     "Unown": {
-      "codename": "201"
+      "codename": "201",
+      "locale": {
+        "fr": "Zarbi",
+        "de": "Icognito",
+        "ko": "\uc548\ub18d",
+        "ja": "\u30a2\u30f3\u30ce\u30fc\u30f3",
+        "zh_CN": "\u672a\u77e5\u56fe\u817e",
+        "zh_TW": "\u672a\u77e5\u5716\u9a30"
+      }
     },
     "Wobbuffet": {
-      "codename": "202"
+      "codename": "202",
+      "locale": {
+        "fr": "Qulbutok\u00e9",
+        "de": "Woingenau",
+        "ko": "\ub9c8\uc790\uc6a9",
+        "ja": "\u30bd\u30fc\u30ca\u30f3\u30b9",
+        "zh_CN": "\u679c\u7136\u7fc1",
+        "zh_TW": "\u679c\u7136\u7fc1"
+      }
     },
     "Girafarig": {
-      "codename": "203"
+      "codename": "203",
+      "locale": {
+        "fr": "Girafarig",
+        "de": "Girafarig",
+        "ko": "\ud0a4\ub9c1\ud0a4",
+        "ja": "\u30ad\u30ea\u30f3\u30ea\u30ad",
+        "zh_CN": "\u9e92\u9e9f\u5947",
+        "zh_TW": "\u9e92\u9e9f\u5947"
+      }
     },
     "Pineco": {
-      "codename": "204"
+      "codename": "204",
+      "locale": {
+        "fr": "Pomdepic",
+        "de": "Tannza",
+        "ko": "\ud53c\ucf58",
+        "ja": "\u30af\u30cc\u30ae\u30c0\u30de",
+        "zh_CN": "\u699b\u679c\u7403",
+        "zh_TW": "\u699b\u679c\u7403"
+      }
     },
     "Forretress": {
-      "codename": "205"
+      "codename": "205",
+      "locale": {
+        "fr": "Foretress",
+        "de": "Forstellka",
+        "ko": "\uc3d8\ucf58",
+        "ja": "\u30d5\u30a9\u30ec\u30c8\u30b9",
+        "zh_CN": "\u4f5b\u70c8\u6258\u65af",
+        "zh_TW": "\u4f5b\u70c8\u6258\u65af"
+      }
     },
     "Dunsparce": {
-      "codename": "206"
+      "codename": "206",
+      "locale": {
+        "fr": "Insolourdo",
+        "de": "Dummisel",
+        "ko": "\ub178\uace0\uce58",
+        "ja": "\u30ce\u30b3\u30c3\u30c1",
+        "zh_CN": "\u571f\u9f99\u5f1f\u5f1f",
+        "zh_TW": "\u571f\u9f8d\u5f1f\u5f1f"
+      }
     },
     "Gligar": {
-      "codename": "207"
+      "codename": "207",
+      "locale": {
+        "fr": "Scorplane",
+        "de": "Skorgla",
+        "ko": "\uae00\ub77c\uc774\uac70",
+        "ja": "\u30b0\u30e9\u30a4\u30ac\u30fc",
+        "zh_CN": "\u5929\u874e",
+        "zh_TW": "\u5929\u880d"
+      }
     },
     "Steelix": {
-      "codename": "208"
+      "codename": "208",
+      "locale": {
+        "fr": "Steelix",
+        "de": "Stahlos",
+        "ko": "\uac15\ucca0\ud1a4",
+        "ja": "\u30cf\u30ac\u30cd\u30fc\u30eb",
+        "zh_CN": "\u5927\u94a2\u86c7",
+        "zh_TW": "\u5927\u92fc\u86c7"
+      }
     },
     "Snubbull": {
-      "codename": "209"
+      "codename": "209",
+      "locale": {
+        "fr": "Snubbull",
+        "de": "Snubbull",
+        "ko": "\ube14\ub8e8",
+        "ja": "\u30d6\u30eb\u30fc",
+        "zh_CN": "\u5e03\u5362",
+        "zh_TW": "\u5e03\u76e7"
+      }
     },
     "Granbull": {
-      "codename": "210"
+      "codename": "210",
+      "locale": {
+        "fr": "Granbull",
+        "de": "Granbull",
+        "ko": "\uadf8\ub791\ube14\ub8e8",
+        "ja": "\u30b0\u30e9\u30f3\u30d6\u30eb",
+        "zh_CN": "\u5e03\u5362\u7687",
+        "zh_TW": "\u5e03\u76e7\u7687"
+      }
     },
     "Qwilfish": {
-      "codename": "211"
+      "codename": "211",
+      "locale": {
+        "fr": "Qwilfish",
+        "de": "Baldorfish",
+        "ko": "\uce68\ubc14\ub8e8",
+        "ja": "\u30cf\u30ea\u30fc\u30bb\u30f3",
+        "zh_CN": "\u5343\u9488\u9c7c",
+        "zh_TW": "\u5343\u91dd\u9b5a"
+      }
     },
     "Scizor": {
-      "codename": "212"
+      "codename": "212",
+      "locale": {
+        "fr": "Cizayox",
+        "de": "Scherox",
+        "ko": "\ud56b\uc0bc",
+        "ja": "\u30cf\u30c3\u30b5\u30e0",
+        "zh_CN": "\u5de8\u94b3\u87b3\u8782",
+        "zh_TW": "\u5de8\u9257\u87b3\u8782"
+      }
     },
     "Shuckle": {
-      "codename": "213"
+      "codename": "213",
+      "locale": {
+        "fr": "Caratroc",
+        "de": "Pottrott",
+        "ko": "\ub2e8\ub2e8\uc9c0",
+        "ja": "\u30c4\u30dc\u30c4\u30dc",
+        "zh_CN": "\u58f6\u58f6",
+        "zh_TW": "\u58fa\u58fa"
+      }
     },
     "Heracross": {
-      "codename": "214"
+      "codename": "214",
+      "locale": {
+        "fr": "Scarhino",
+        "de": "Skaraborn",
+        "ko": "\ud5e4\ub77c\ud06c\ub85c\uc2a4",
+        "ja": "\u30d8\u30e9\u30af\u30ed\u30b9",
+        "zh_CN": "\u8d6b\u62c9\u514b\u7f57\u65af",
+        "zh_TW": "\u8d6b\u62c9\u524b\u7f85\u65af"
+      }
     },
     "Sneasel": {
-      "codename": "215"
+      "codename": "215",
+      "locale": {
+        "fr": "Farfuret",
+        "de": "Sniebel",
+        "ko": "\ud3ec\ud478\ub2c8",
+        "ja": "\u30cb\u30e5\u30fc\u30e9",
+        "zh_CN": "\u72c3\u62c9",
+        "zh_TW": "\u72c3\u62c9"
+      }
     },
     "Teddiursa": {
-      "codename": "216"
+      "codename": "216",
+      "locale": {
+        "fr": "Teddiursa",
+        "de": "Teddiursa",
+        "ko": "\uae5c\uc9c0\uacf0",
+        "ja": "\u30d2\u30e1\u30b0\u30de",
+        "zh_CN": "\u718a\u5b9d\u5b9d",
+        "zh_TW": "\u718a\u5bf6\u5bf6"
+      }
     },
     "Ursaring": {
-      "codename": "217"
+      "codename": "217",
+      "locale": {
+        "fr": "Ursaring",
+        "de": "Ursaring",
+        "ko": "\ub9c1\uacf0",
+        "ja": "\u30ea\u30f3\u30b0\u30de",
+        "zh_CN": "\u5708\u5708\u718a",
+        "zh_TW": "\u5708\u5708\u718a"
+      }
     },
     "Slugma": {
-      "codename": "218"
+      "codename": "218",
+      "locale": {
+        "fr": "Limagma",
+        "de": "Schneckmag",
+        "ko": "\ub9c8\uadf8\ub9c8\uadf8",
+        "ja": "\u30de\u30b0\u30de\u30c3\u30b0",
+        "zh_CN": "\u7194\u5ca9\u866b",
+        "zh_TW": "\u7194\u5ca9\u87f2"
+      }
     },
     "Magcargo": {
-      "codename": "219"
+      "codename": "219",
+      "locale": {
+        "fr": "Volcaropod",
+        "de": "Magcargo",
+        "ko": "\ub9c8\uadf8\uce74\ub974\uace0",
+        "ja": "\u30de\u30b0\u30ab\u30eb\u30b4",
+        "zh_CN": "\u7194\u5ca9\u8717\u725b",
+        "zh_TW": "\u7194\u5ca9\u8778\u725b"
+      }
     },
     "Swinub": {
-      "codename": "220"
+      "codename": "220",
+      "locale": {
+        "fr": "Marcacrin",
+        "de": "Quiekel",
+        "ko": "\uafb8\uafb8\ub9ac",
+        "ja": "\u30a6\u30ea\u30e0\u30fc",
+        "zh_CN": "\u5c0f\u5c71\u732a",
+        "zh_TW": "\u5c0f\u5c71\u8c6c"
+      }
     },
     "Piloswine": {
-      "codename": "221"
+      "codename": "221",
+      "locale": {
+        "fr": "Cochignon",
+        "de": "Keifel",
+        "ko": "\uba54\uafb8\ub9ac",
+        "ja": "\u30a4\u30ce\u30e0\u30fc",
+        "zh_CN": "\u957f\u6bdb\u732a",
+        "zh_TW": "\u9577\u6bdb\u8c6c"
+      }
     },
     "Corsola": {
-      "codename": "222"
+      "codename": "222",
+      "locale": {
+        "fr": "Corayon",
+        "de": "Corasonn",
+        "ko": "\ucf54\uc0b0\ud638",
+        "ja": "\u30b5\u30cb\u30fc\u30b4",
+        "zh_CN": "\u592a\u9633\u73ca\u745a",
+        "zh_TW": "\u592a\u967d\u73ca\u745a"
+      }
     },
     "Remoraid": {
-      "codename": "223"
+      "codename": "223",
+      "locale": {
+        "fr": "R\u00e9moraid",
+        "de": "Remoraid",
+        "ko": "\ucd1d\uc5b4",
+        "ja": "\u30c6\u30c3\u30dd\u30a6\u30aa",
+        "zh_CN": "\u94c1\u70ae\u9c7c",
+        "zh_TW": "\u9435\u70ae\u9b5a"
+      }
     },
     "Octillery": {
-      "codename": "224"
+      "codename": "224",
+      "locale": {
+        "fr": "Octillery",
+        "de": "Octillery",
+        "ko": "\ub300\ud3ec\ubb34\ub178",
+        "ja": "\u30aa\u30af\u30bf\u30f3",
+        "zh_CN": "\u7ae0\u9c7c\u6876",
+        "zh_TW": "\u7ae0\u9b5a\u6876"
+      }
     },
     "Delibird": {
-      "codename": "225"
+      "codename": "225",
+      "locale": {
+        "fr": "Cadoizo",
+        "de": "Botogel",
+        "ko": "\ub51c\ub9ac\ubc84\ub4dc",
+        "ja": "\u30c7\u30ea\u30d0\u30fc\u30c9",
+        "zh_CN": "\u4fe1\u4f7f\u9e1f",
+        "zh_TW": "\u4fe1\u4f7f\u9ce5"
+      }
     },
     "Mantine": {
-      "codename": "226"
+      "codename": "226",
+      "locale": {
+        "fr": "D\u00e9manta",
+        "de": "Mantax",
+        "ko": "\ub9cc\ud0c0\uc778",
+        "ja": "\u30de\u30f3\u30bf\u30a4\u30f3",
+        "zh_CN": "\u5de8\u7fc5\u98de\u9c7c",
+        "zh_TW": "\u5de8\u7fc5\u98db\u9b5a"
+      }
     },
     "Skarmory": {
-      "codename": "227"
+      "codename": "227",
+      "locale": {
+        "fr": "Airmure",
+        "de": "Panzaeron",
+        "ko": "\ubb34\uc7a5\uc870",
+        "ja": "\u30a8\u30a2\u30fc\u30e0\u30c9",
+        "zh_CN": "\u76d4\u7532\u9e1f",
+        "zh_TW": "\u76d4\u7532\u9ce5"
+      }
     },
     "Houndour": {
-      "codename": "228"
+      "codename": "228",
+      "locale": {
+        "fr": "Malosse",
+        "de": "Hunduster",
+        "ko": "\ub378\ube4c",
+        "ja": "\u30c7\u30eb\u30d3\u30eb",
+        "zh_CN": "\u6234\u9c81\u6bd4",
+        "zh_TW": "\u6234\u9b6f\u6bd4"
+      }
     },
     "Houndoom": {
-      "codename": "229"
+      "codename": "229",
+      "locale": {
+        "fr": "D\u00e9molosse",
+        "de": "Hundemon",
+        "ko": "\ud5ec\uac00",
+        "ja": "\u30d8\u30eb\u30ac\u30fc",
+        "zh_CN": "\u9ed1\u9c81\u52a0",
+        "zh_TW": "\u9ed1\u9b6f\u52a0"
+      }
     },
     "Kingdra": {
-      "codename": "230"
+      "codename": "230",
+      "locale": {
+        "fr": "Hyporoi",
+        "de": "Seedraking",
+        "ko": "\ud0b9\ub4dc\ub77c",
+        "ja": "\u30ad\u30f3\u30b0\u30c9\u30e9",
+        "zh_CN": "\u523a\u9f99\u738b",
+        "zh_TW": "\u523a\u9f8d\u738b"
+      }
     },
     "Phanpy": {
-      "codename": "231"
+      "codename": "231",
+      "locale": {
+        "fr": "Phanpy",
+        "de": "Phanpy",
+        "ko": "\ucf54\ucf54\ub9ac",
+        "ja": "\u30b4\u30de\u30be\u30a6",
+        "zh_CN": "\u5c0f\u5c0f\u8c61",
+        "zh_TW": "\u5c0f\u5c0f\u8c61"
+      }
     },
     "Donphan": {
-      "codename": "232"
+      "codename": "232",
+      "locale": {
+        "fr": "Donphan",
+        "de": "Donphan",
+        "ko": "\ucf54\ub9ac\uac11",
+        "ja": "\u30c9\u30f3\u30d5\u30a1\u30f3",
+        "zh_CN": "\u987f\u7532",
+        "zh_TW": "\u9813\u7532"
+      }
     },
     "Porygon2": {
-      "codename": "233"
+      "codename": "233",
+      "locale": {
+        "fr": "Porygon2",
+        "de": "Porygon2",
+        "ko": "\ud3f4\ub9ac\uace42",
+        "ja": "\u30dd\u30ea\u30b4\u30f3\uff12",
+        "zh_CN": "3D\u9f99II",
+        "zh_TW": "3D\u9f8d2"
+      }
     },
     "Stantler": {
-      "codename": "234"
+      "codename": "234",
+      "locale": {
+        "fr": "Cerfrousse",
+        "de": "Damhirplex",
+        "ko": "\ub178\ub77c\ud0a4",
+        "ja": "\u30aa\u30c9\u30b7\u30b7",
+        "zh_CN": "\u60ca\u89d2\u9e7f",
+        "zh_TW": "\u9a5a\u89d2\u9e7f"
+      }
     },
     "Smeargle": {
-      "codename": "235"
+      "codename": "235",
+      "locale": {
+        "fr": "Queulorior",
+        "de": "Farbeagle",
+        "ko": "\ub8e8\ube0c\ub3c4",
+        "ja": "\u30c9\u30fc\u30d6\u30eb",
+        "zh_CN": "\u56fe\u56fe\u72ac",
+        "zh_TW": "\u5716\u5716\u72ac"
+      }
     },
     "Tyrogue": {
-      "codename": "236"
+      "codename": "236",
+      "locale": {
+        "fr": "Debugant",
+        "de": "Rabauz",
+        "ko": "\ubc30\ub8e8\ud0a4",
+        "ja": "\u30d0\u30eb\u30ad\u30fc",
+        "zh_CN": "\u5df4\u5c14\u90ce",
+        "zh_TW": "\u5df4\u723e\u90ce"
+      }
     },
     "Hitmontop": {
-      "codename": "237"
+      "codename": "237",
+      "locale": {
+        "fr": "Kapoera",
+        "de": "Kapoera",
+        "ko": "\uce74\ud3ec\uc5d0\ub77c",
+        "ja": "\u30ab\u30dd\u30a8\u30e9\u30fc",
+        "zh_CN": "\u67ef\u6ce2\u6717",
+        "zh_TW": "\u67ef\u6ce2\u6717"
+      }
     },
     "Smoochum": {
-      "codename": "238"
+      "codename": "238",
+      "locale": {
+        "fr": "Lippouti",
+        "de": "Kussilla",
+        "ko": "\ubf40\ubf40\ub77c",
+        "ja": "\u30e0\u30c1\u30e5\u30fc\u30eb",
+        "zh_CN": "\u8ff7\u5507\u5a03",
+        "zh_TW": "\u8ff7\u5507\u5a03"
+      }
     },
     "Elekid": {
-      "codename": "239"
+      "codename": "239",
+      "locale": {
+        "fr": "\u00c9lekid",
+        "de": "Elekid",
+        "ko": "\uc5d0\ub808\ud0a4\ub4dc",
+        "ja": "\u30a8\u30ec\u30ad\u30c3\u30c9",
+        "zh_CN": "\u7535\u51fb\u602a",
+        "zh_TW": "\u96fb\u64ca\u602a"
+      }
     },
     "Magby": {
-      "codename": "240"
+      "codename": "240",
+      "locale": {
+        "fr": "Magby",
+        "de": "Magby",
+        "ko": "\ub9c8\uadf8\ube44",
+        "ja": "\u30d6\u30d3\u30a3",
+        "zh_CN": "\u5c0f\u9e2d\u5634\u9f99",
+        "zh_TW": "\u5c0f\u9d28\u5634\u9f8d"
+      }
     },
     "Miltank": {
-      "codename": "241"
+      "codename": "241",
+      "locale": {
+        "fr": "\u00c9cr\u00e9meuh",
+        "de": "Miltank",
+        "ko": "\ubc00\ud0f1\ud06c",
+        "ja": "\u30df\u30eb\u30bf\u30f3\u30af",
+        "zh_CN": "\u5927\u5976\u7f50",
+        "zh_TW": "\u5927\u5976\u7f50"
+      }
     },
     "Blissey": {
-      "codename": "242"
+      "codename": "242",
+      "locale": {
+        "fr": "Leuphorie",
+        "de": "Heiteira",
+        "ko": "\ud574\ud53c\ub108\uc2a4",
+        "ja": "\u30cf\u30d4\u30ca\u30b9",
+        "zh_CN": "\u5e78\u798f\u86cb",
+        "zh_TW": "\u5e78\u798f\u86cb"
+      }
     },
     "Raikou": {
-      "codename": "243"
+      "codename": "243",
+      "locale": {
+        "fr": "Raikou",
+        "de": "Raikou",
+        "ko": "\ub77c\uc774\ucf54",
+        "ja": "\u30e9\u30a4\u30b3\u30a6",
+        "zh_CN": "\u96f7\u516c",
+        "zh_TW": "\u96f7\u516c"
+      }
     },
     "Entei": {
-      "codename": "244"
+      "codename": "244",
+      "locale": {
+        "fr": "Entei",
+        "de": "Entei",
+        "ko": "\uc564\ud14c\uc774",
+        "ja": "\u30a8\u30f3\u30c6\u30a4",
+        "zh_CN": "\u708e\u5e1d",
+        "zh_TW": "\u708e\u5e1d"
+      }
     },
     "Suicune": {
-      "codename": "245"
+      "codename": "245",
+      "locale": {
+        "fr": "Suicune",
+        "de": "Suicune",
+        "ko": "\uc2a4\uc774\ucfe4",
+        "ja": "\u30b9\u30a4\u30af\u30f3",
+        "zh_CN": "\u6c34\u541b",
+        "zh_TW": "\u6c34\u541b"
+      }
     },
     "Larvitar": {
-      "codename": "246"
+      "codename": "246",
+      "locale": {
+        "fr": "Embrylex",
+        "de": "Larvitar",
+        "ko": "\uc560\ubc84\ub77c\uc2a4",
+        "ja": "\u30e8\u30fc\u30ae\u30e9\u30b9",
+        "zh_CN": "\u7531\u57fa\u62c9",
+        "zh_TW": "\u7531\u57fa\u62c9"
+      }
     },
     "Pupitar": {
-      "codename": "247"
+      "codename": "247",
+      "locale": {
+        "fr": "Ymphect",
+        "de": "Pupitar",
+        "ko": "\ub370\uae30\ub77c\uc2a4",
+        "ja": "\u30b5\u30ca\u30ae\u30e9\u30b9",
+        "zh_CN": "\u6c99\u57fa\u62c9",
+        "zh_TW": "\u6c99\u57fa\u62c9"
+      }
     },
     "Tyranitar": {
-      "codename": "248"
+      "codename": "248",
+      "locale": {
+        "fr": "Tyranocif",
+        "de": "Despotar",
+        "ko": "\ub9c8\uae30\ub77c\uc2a4",
+        "ja": "\u30d0\u30f3\u30ae\u30e9\u30b9",
+        "zh_CN": "\u73ed\u5409\u62c9",
+        "zh_TW": "\u73ed\u5409\u62c9"
+      }
     },
     "Lugia": {
-      "codename": "249"
+      "codename": "249",
+      "locale": {
+        "fr": "Lugia",
+        "de": "Lugia",
+        "ko": "\ub8e8\uae30\uc544",
+        "ja": "\u30eb\u30ae\u30a2",
+        "zh_CN": "\u6d1b\u5947\u4e9a",
+        "zh_TW": "\u6d1b\u5947\u4e9e"
+      }
     },
     "Ho-Oh": {
-      "codename": "250"
+      "codename": "250",
+      "locale": {
+        "fr": "Ho-Oh",
+        "de": "Ho-Oh",
+        "ko": "\uce60\uc0c9\uc870",
+        "ja": "\u30db\u30a6\u30aa\u30a6",
+        "zh_CN": "\u51e4\u738b",
+        "zh_TW": "\u9cf3\u738b"
+      }
     },
     "Celebi": {
-      "codename": "251"
+      "codename": "251",
+      "locale": {
+        "fr": "Celebi",
+        "de": "Celebi",
+        "ko": "\uc138\ub808\ube44",
+        "ja": "\u30bb\u30ec\u30d3\u30a3",
+        "zh_CN": "\u96ea\u62c9\u6bd4",
+        "zh_TW": "\u96ea\u62c9\u6bd4"
+      }
     },
     "Treecko": {
-      "codename": "252"
+      "codename": "252",
+      "locale": {
+        "fr": "Arcko",
+        "de": "Geckarbor",
+        "ko": "\ub098\ubb34\uc9c0\uae30",
+        "ja": "\u30ad\u30e2\u30ea",
+        "zh_CN": "\u6728\u5b88\u5bab",
+        "zh_TW": "\u6728\u5b88\u5bae"
+      }
     },
     "Grovyle": {
-      "codename": "253"
+      "codename": "253",
+      "locale": {
+        "fr": "Massko",
+        "de": "Reptain",
+        "ko": "\ub098\ubb34\ub3cc\uc774",
+        "ja": "\u30b8\u30e5\u30d7\u30c8\u30eb",
+        "zh_CN": "\u68ee\u6797\u8725\u8734",
+        "zh_TW": "\u68ee\u6797\u8725\u8734"
+      }
     },
     "Sceptile": {
-      "codename": "254"
+      "codename": "254",
+      "locale": {
+        "fr": "Jungko",
+        "de": "Gewaldro",
+        "ko": "\ub098\ubb34\ud0b9",
+        "ja": "\u30b8\u30e5\u30ab\u30a4\u30f3",
+        "zh_CN": "\u8725\u8734\u738b",
+        "zh_TW": "\u8725\u8734\u738b"
+      }
     },
     "Torchic": {
-      "codename": "255"
+      "codename": "255",
+      "locale": {
+        "fr": "Poussifeu",
+        "de": "Flemmli",
+        "ko": "\uc544\ucc28\ubaa8",
+        "ja": "\u30a2\u30c1\u30e3\u30e2",
+        "zh_CN": "\u706b\u7a1a\u9e21",
+        "zh_TW": "\u706b\u7a1a\u96de"
+      }
     },
     "Combusken": {
-      "codename": "256"
+      "codename": "256",
+      "locale": {
+        "fr": "Galifeu",
+        "de": "Jungglut",
+        "ko": "\uc601\uce58\ucf54",
+        "ja": "\u30ef\u30ab\u30b7\u30e3\u30e2",
+        "zh_CN": "\u529b\u58ee\u9e21",
+        "zh_TW": "\u529b\u58ef\u96de"
+      }
     },
     "Blaziken": {
-      "codename": "257"
+      "codename": "257",
+      "locale": {
+        "fr": "Bras\u00e9gali",
+        "de": "Lohgock",
+        "ko": "\ubc88\uce58\ucf54",
+        "ja": "\u30d0\u30b7\u30e3\u30fc\u30e2",
+        "zh_CN": "\u706b\u7130\u9e21",
+        "zh_TW": "\u706b\u7130\u96de"
+      }
     },
     "Mudkip": {
-      "codename": "258"
+      "codename": "258",
+      "locale": {
+        "fr": "Gobou",
+        "de": "Hydropi",
+        "ko": "\ubb3c\uc9f1\uc774",
+        "ja": "\u30df\u30ba\u30b4\u30ed\u30a6",
+        "zh_CN": "\u6c34\u8dc3\u9c7c",
+        "zh_TW": "\u6c34\u8e8d\u9b5a"
+      }
     },
     "Marshtomp": {
-      "codename": "259"
+      "codename": "259",
+      "locale": {
+        "fr": "Flobio",
+        "de": "Moorabbel",
+        "ko": "\ub2aa\uc9f1\uc774",
+        "ja": "\u30cc\u30de\u30af\u30ed\u30fc",
+        "zh_CN": "\u6cbc\u8dc3\u9c7c",
+        "zh_TW": "\u6cbc\u8e8d\u9b5a"
+      }
     },
     "Swampert": {
-      "codename": "260"
+      "codename": "260",
+      "locale": {
+        "fr": "Laggron",
+        "de": "Sumpex",
+        "ko": "\ub300\uc9f1\uc774",
+        "ja": "\u30e9\u30b0\u30e9\u30fc\u30b8",
+        "zh_CN": "\u5de8\u6cbc\u602a",
+        "zh_TW": "\u5de8\u6cbc\u602a"
+      }
     },
     "Poochyena": {
-      "codename": "261"
+      "codename": "261",
+      "locale": {
+        "fr": "Medhy\u00e8na",
+        "de": "Fiffyen",
+        "ko": "\ud3ec\ucc60\ub098",
+        "ja": "\u30dd\u30c1\u30a8\u30ca",
+        "zh_CN": "\u571f\u72fc\u72ac",
+        "zh_TW": "\u571f\u72fc\u72ac"
+      }
     },
     "Mightyena": {
-      "codename": "262"
+      "codename": "262",
+      "locale": {
+        "fr": "Grahy\u00e8na",
+        "de": "Magnayen",
+        "ko": "\uadf8\ub77c\uc5d0\ub098",
+        "ja": "\u30b0\u30e9\u30a8\u30ca",
+        "zh_CN": "\u5927\u72fc\u72ac",
+        "zh_TW": "\u5927\u72fc\u72ac"
+      }
     },
     "Zigzagoon": {
-      "codename": "263"
+      "codename": "263",
+      "locale": {
+        "fr": "Zigzaton",
+        "de": "Zigzachs",
+        "ko": "\uc9c0\uadf8\uc81c\uad6c\ub9ac",
+        "ja": "\u30b8\u30b0\u30b6\u30b0\u30de",
+        "zh_CN": "\u86c7\u7eb9\u718a",
+        "zh_TW": "\u86c7\u7d0b\u718a"
+      }
     },
     "Linoone": {
-      "codename": "264"
+      "codename": "264",
+      "locale": {
+        "fr": "Lin\u00e9on",
+        "de": "Geradaks",
+        "ko": "\uc9c1\uad6c\ub9ac",
+        "ja": "\u30de\u30c3\u30b9\u30b0\u30de",
+        "zh_CN": "\u76f4\u51b2\u718a",
+        "zh_TW": "\u76f4\u885d\u718a"
+      }
     },
     "Wurmple": {
-      "codename": "265"
+      "codename": "265",
+      "locale": {
+        "fr": "Chenipotte",
+        "de": "Waumpel",
+        "ko": "\uac1c\ubb34\uc18c",
+        "ja": "\u30b1\u30e0\u30c3\u30bd",
+        "zh_CN": "\u523a\u5c3e\u866b",
+        "zh_TW": "\u523a\u5c3e\u87f2"
+      }
     },
     "Silcoon": {
-      "codename": "266"
+      "codename": "266",
+      "locale": {
+        "fr": "Armulys",
+        "de": "Schaloko",
+        "ko": "\uc2e4\ucfe4",
+        "ja": "\u30ab\u30e9\u30b5\u30ea\u30b9",
+        "zh_CN": "\u7532\u58f3\u86f9",
+        "zh_TW": "\u7532\u6bbc\u86f9"
+      }
     },
     "Beautifly": {
-      "codename": "267"
+      "codename": "267",
+      "locale": {
+        "fr": "Charmillon",
+        "de": "Papinella",
+        "ko": "\ubdf0\ud2f0\ud50c\ub77c\uc774",
+        "ja": "\u30a2\u30b2\u30cf\u30f3\u30c8",
+        "zh_CN": "\u72e9\u730e\u51e4\u8776",
+        "zh_TW": "\u72e9\u7375\u9cf3\u8776"
+      }
     },
     "Cascoon": {
-      "codename": "268"
+      "codename": "268",
+      "locale": {
+        "fr": "Blindalys",
+        "de": "Panekon",
+        "ko": "\uce74\uc2a4\ucfe4",
+        "ja": "\u30de\u30e6\u30eb\u30c9",
+        "zh_CN": "\u76fe\u7532\u8327",
+        "zh_TW": "\u76fe\u7532\u7e6d"
+      }
     },
     "Dustox": {
-      "codename": "269"
+      "codename": "269",
+      "locale": {
+        "fr": "Papinox",
+        "de": "Pudox",
+        "ko": "\ub3c5\ucf00\uc77c",
+        "ja": "\u30c9\u30af\u30b1\u30a4\u30eb",
+        "zh_CN": "\u6bd2\u7c89\u8776",
+        "zh_TW": "\u6bd2\u7c89\u8776"
+      }
     },
     "Lotad": {
-      "codename": "270"
+      "codename": "270",
+      "locale": {
+        "fr": "N\u00e9nupiot",
+        "de": "Loturzel",
+        "ko": "\uc5f0\uaf43\ubaac",
+        "ja": "\u30cf\u30b9\u30dc\u30fc",
+        "zh_CN": "\u83b2\u53f6\u7ae5\u5b50",
+        "zh_TW": "\u84ee\u8449\u7ae5\u5b50"
+      }
     },
     "Lombre": {
-      "codename": "271"
+      "codename": "271",
+      "locale": {
+        "fr": "Lombre",
+        "de": "Lombrero",
+        "ko": "\ub85c\ud1a0\uc2a4",
+        "ja": "\u30cf\u30b9\u30d6\u30ec\u30ed",
+        "zh_CN": "\u83b2\u5e3d\u5c0f\u7ae5",
+        "zh_TW": "\u84ee\u5e3d\u5c0f\u7ae5"
+      }
     },
     "Ludicolo": {
-      "codename": "272"
+      "codename": "272",
+      "locale": {
+        "fr": "Ludicolo",
+        "de": "Kappalores",
+        "ko": "\ub85c\ud30c\ud30c",
+        "ja": "\u30eb\u30f3\u30d1\u30c3\u30d1",
+        "zh_CN": "\u4e50\u5929\u6cb3\u7ae5",
+        "zh_TW": "\u6a02\u5929\u6cb3\u7ae5"
+      }
     },
     "Seedot": {
-      "codename": "273"
+      "codename": "273",
+      "locale": {
+        "fr": "Grainipiot",
+        "de": "Samurzel",
+        "ko": "\ub3c4\ud1a0\ub9c1",
+        "ja": "\u30bf\u30cd\u30dc\u30fc",
+        "zh_CN": "\u6a61\u5b9e\u679c",
+        "zh_TW": "\u6a61\u5be6\u679c"
+      }
     },
     "Nuzleaf": {
-      "codename": "274"
+      "codename": "274",
+      "locale": {
+        "fr": "Pifeuil",
+        "de": "Blanas",
+        "ko": "\uc78e\uc0c8\ucf54",
+        "ja": "\u30b3\u30ce\u30cf\u30ca",
+        "zh_CN": "\u957f\u9f3b\u53f6",
+        "zh_TW": "\u9577\u9f3b\u8449"
+      }
     },
     "Shiftry": {
-      "codename": "275"
+      "codename": "275",
+      "locale": {
+        "fr": "Tengalice",
+        "de": "Tengulist",
+        "ko": "\ub2e4\ud0f1\uad6c",
+        "ja": "\u30c0\u30fc\u30c6\u30f3\u30b0",
+        "zh_CN": "\u72e1\u733e\u5929\u72d7",
+        "zh_TW": "\u72e1\u733e\u5929\u72d7"
+      }
     },
     "Taillow": {
-      "codename": "276"
+      "codename": "276",
+      "locale": {
+        "fr": "Nirondelle",
+        "de": "Schwalbini",
+        "ko": "\ud14c\uc77c\ub85c",
+        "ja": "\u30b9\u30d0\u30e1",
+        "zh_CN": "\u50b2\u9aa8\u71d5",
+        "zh_TW": "\u50b2\u9aa8\u71d5"
+      }
     },
     "Swellow": {
-      "codename": "277"
+      "codename": "277",
+      "locale": {
+        "fr": "H\u00e9l\u00e9delle",
+        "de": "Schwalboss",
+        "ko": "\uc2a4\uc648\ub85c",
+        "ja": "\u30aa\u30aa\u30b9\u30d0\u30e1",
+        "zh_CN": "\u5927\u738b\u71d5",
+        "zh_TW": "\u5927\u738b\u71d5"
+      }
     },
     "Wingull": {
-      "codename": "278"
+      "codename": "278",
+      "locale": {
+        "fr": "Go\u00e9lise",
+        "de": "Wingull",
+        "ko": "\uac08\ubaa8\ub9e4",
+        "ja": "\u30ad\u30e3\u30e2\u30e1",
+        "zh_CN": "\u957f\u7fc5\u9e25",
+        "zh_TW": "\u9577\u7fc5\u9dd7"
+      }
     },
     "Pelipper": {
-      "codename": "279"
+      "codename": "279",
+      "locale": {
+        "fr": "Bekipan",
+        "de": "Pelipper",
+        "ko": "\ud328\ub9ac\ud37c",
+        "ja": "\u30da\u30ea\u30c3\u30d1\u30fc",
+        "zh_CN": "\u5927\u5634\u9e25",
+        "zh_TW": "\u5927\u5634\u9dd7"
+      }
     },
     "Ralts": {
-      "codename": "280"
+      "codename": "280",
+      "locale": {
+        "fr": "Tarsal",
+        "de": "Trasla",
+        "ko": "\ub784\ud1a0\uc2a4",
+        "ja": "\u30e9\u30eb\u30c8\u30b9",
+        "zh_CN": "\u62c9\u9c81\u62c9\u4e1d",
+        "zh_TW": "\u62c9\u9b6f\u62c9\u7d72"
+      }
     },
     "Kirlia": {
-      "codename": "281"
+      "codename": "281",
+      "locale": {
+        "fr": "Kirlia",
+        "de": "Kirlia",
+        "ko": "\ud0ac\ub9ac\uc544",
+        "ja": "\u30ad\u30eb\u30ea\u30a2",
+        "zh_CN": "\u5947\u9c81\u8389\u5b89",
+        "zh_TW": "\u5947\u9b6f\u8389\u5b89"
+      }
     },
     "Gardevoir": {
-      "codename": "282"
+      "codename": "282",
+      "locale": {
+        "fr": "Gardevoir",
+        "de": "Guardevoir",
+        "ko": "\uac00\ub514\uc548",
+        "ja": "\u30b5\u30fc\u30ca\u30a4\u30c8",
+        "zh_CN": "\u6c99\u5948\u6735",
+        "zh_TW": "\u6c99\u5948\u6735"
+      }
     },
     "Surskit": {
-      "codename": "283"
+      "codename": "283",
+      "locale": {
+        "fr": "Arakdo",
+        "de": "Gehweiher",
+        "ko": "\ube44\uad6c\uc220",
+        "ja": "\u30a2\u30e1\u30bf\u30de",
+        "zh_CN": "\u6e9c\u6e9c\u7cd6\u7403",
+        "zh_TW": "\u6e9c\u6e9c\u7cd6\u7403"
+      }
     },
     "Masquerain": {
-      "codename": "284"
+      "codename": "284",
+      "locale": {
+        "fr": "Maskadra",
+        "de": "Maskeregen",
+        "ko": "\ube44\ub098\ubc29",
+        "ja": "\u30a2\u30e1\u30e2\u30fc\u30b9",
+        "zh_CN": "\u96e8\u7fc5\u86fe",
+        "zh_TW": "\u96e8\u7fc5\u86fe"
+      }
     },
     "Shroomish": {
-      "codename": "285"
+      "codename": "285",
+      "locale": {
+        "fr": "Balignon",
+        "de": "Knilz",
+        "ko": "\ubc84\uc12f\uaf2c",
+        "ja": "\u30ad\u30ce\u30b3\u30b3",
+        "zh_CN": "\u8611\u8611\u83c7",
+        "zh_TW": "\u8611\u8611\u83c7"
+      }
     },
     "Breloom": {
-      "codename": "286"
+      "codename": "286",
+      "locale": {
+        "fr": "Chapignon",
+        "de": "Kapilz",
+        "ko": "\ubc84\uc12f\ubaa8",
+        "ja": "\u30ad\u30ce\u30ac\u30c3\u30b5",
+        "zh_CN": "\u6597\u7b20\u83c7",
+        "zh_TW": "\u6597\u7b20\u83c7"
+      }
     },
     "Slakoth": {
-      "codename": "287"
+      "codename": "287",
+      "locale": {
+        "fr": "Parecool",
+        "de": "Bummelz",
+        "ko": "\uac8c\uc744\ub85c",
+        "ja": "\u30ca\u30de\u30b1\u30ed",
+        "zh_CN": "\u61d2\u4eba\u7fc1",
+        "zh_TW": "\u61f6\u4eba\u7fc1"
+      }
     },
     "Vigoroth": {
-      "codename": "288"
+      "codename": "288",
+      "locale": {
+        "fr": "Vigoroth",
+        "de": "Muntier",
+        "ko": "\ubc1c\ubc14\ub85c",
+        "ja": "\u30e4\u30eb\u30ad\u30e2\u30ce",
+        "zh_CN": "\u8fc7\u52a8\u733f",
+        "zh_TW": "\u904e\u52d5\u733f"
+      }
     },
     "Slaking": {
-      "codename": "289"
+      "codename": "289",
+      "locale": {
+        "fr": "Monafl\u00e8mit",
+        "de": "Letarking",
+        "ko": "\uac8c\uc744\ud0b9",
+        "ja": "\u30b1\u30c3\u30ad\u30f3\u30b0",
+        "zh_CN": "\u8bf7\u5047\u738b",
+        "zh_TW": "\u8acb\u5047\u738b"
+      }
     },
     "Nincada": {
-      "codename": "290"
+      "codename": "290",
+      "locale": {
+        "fr": "Ningale",
+        "de": "Nincada",
+        "ko": "\ud1a0\uc911\ubaac",
+        "ja": "\u30c4\u30c1\u30cb\u30f3",
+        "zh_CN": "\u571f\u5c45\u5fcd\u58eb",
+        "zh_TW": "\u571f\u5c45\u5fcd\u58eb"
+      }
     },
     "Ninjask": {
-      "codename": "291"
+      "codename": "291",
+      "locale": {
+        "fr": "Ninjask",
+        "de": "Ninjask",
+        "ko": "\uc544\uc774\uc2a4\ud06c",
+        "ja": "\u30c6\u30c3\u30ab\u30cb\u30f3",
+        "zh_CN": "\u94c1\u9762\u5fcd\u8005",
+        "zh_TW": "\u9435\u9762\u5fcd\u8005"
+      }
     },
     "Shedinja": {
-      "codename": "292"
+      "codename": "292",
+      "locale": {
+        "fr": "Munja",
+        "de": "Ninjatom",
+        "ko": "\uaecd\uc9c8\ubaac",
+        "ja": "\u30cc\u30b1\u30cb\u30f3",
+        "zh_CN": "\u8131\u58f3\u5fcd\u8005",
+        "zh_TW": "\u812b\u6bbc\u5fcd\u8005"
+      }
     },
     "Whismur": {
-      "codename": "293"
+      "codename": "293",
+      "locale": {
+        "fr": "Chuchmur",
+        "de": "Flurmel",
+        "ko": "\uc18c\uace4\ub8e1",
+        "ja": "\u30b4\u30cb\u30e7\u30cb\u30e7",
+        "zh_CN": "\u5495\u599e\u599e",
+        "zh_TW": "\u5495\u599e\u599e"
+      }
     },
     "Loudred": {
-      "codename": "294"
+      "codename": "294",
+      "locale": {
+        "fr": "Ramboum",
+        "de": "Krakeelo",
+        "ko": "\ub178\uacf5\ub8e1",
+        "ja": "\u30c9\u30b4\u30fc\u30e0",
+        "zh_CN": "\u543c\u7206\u5f39",
+        "zh_TW": "\u543c\u7206\u5f48"
+      }
     },
     "Exploud": {
-      "codename": "295"
+      "codename": "295",
+      "locale": {
+        "fr": "Brouhabam",
+        "de": "Krawumms",
+        "ko": "\ud3ed\uc74c\ub8e1",
+        "ja": "\u30d0\u30af\u30aa\u30f3\u30b0",
+        "zh_CN": "\u7206\u97f3\u602a",
+        "zh_TW": "\u7206\u97f3\u602a"
+      }
     },
     "Makuhita": {
-      "codename": "296"
+      "codename": "296",
+      "locale": {
+        "fr": "Makuhita",
+        "de": "Makuhita",
+        "ko": "\ub9c8\ud06c\ud0d5",
+        "ja": "\u30de\u30af\u30ce\u30b7\u30bf",
+        "zh_CN": "\u5e55\u4e0b\u529b\u58eb",
+        "zh_TW": "\u5e55\u4e0b\u529b\u58eb"
+      }
     },
     "Hariyama": {
-      "codename": "297"
+      "codename": "297",
+      "locale": {
+        "fr": "Hariyama",
+        "de": "Hariyama",
+        "ko": "\ud558\ub9ac\ubb49",
+        "ja": "\u30cf\u30ea\u30c6\u30e4\u30de",
+        "zh_CN": "\u8d85\u529b\u738b",
+        "zh_TW": "\u8d85\u529b\u738b"
+      }
     },
     "Azurill": {
-      "codename": "298"
+      "codename": "298",
+      "locale": {
+        "fr": "Azurill",
+        "de": "Azurill",
+        "ko": "\ub8e8\ub9ac\ub9ac",
+        "ja": "\u30eb\u30ea\u30ea",
+        "zh_CN": "\u9732\u529b\u4e3d",
+        "zh_TW": "\u9732\u529b\u9e97"
+      }
     },
     "Nosepass": {
-      "codename": "299"
+      "codename": "299",
+      "locale": {
+        "fr": "Tarinor",
+        "de": "Nasgnet",
+        "ko": "\ucf54\ucf54\ud30c\uc2a4",
+        "ja": "\u30ce\u30ba\u30d1\u30b9",
+        "zh_CN": "\u671d\u5317\u9f3b",
+        "zh_TW": "\u671d\u5317\u9f3b"
+      }
     },
     "Skitty": {
-      "codename": "300"
+      "codename": "300",
+      "locale": {
+        "fr": "Skitty",
+        "de": "Eneco",
+        "ko": "\uc5d0\ub098\ube44",
+        "ja": "\u30a8\u30cd\u30b3",
+        "zh_CN": "\u5411\u5c3e\u55b5",
+        "zh_TW": "\u5411\u5c3e\u55b5"
+      }
     },
     "Delcatty": {
-      "codename": "301"
+      "codename": "301",
+      "locale": {
+        "fr": "Delcatty",
+        "de": "Enekoro",
+        "ko": "\ub378\ucf00\ud2f0",
+        "ja": "\u30a8\u30cd\u30b3\u30ed\u30ed",
+        "zh_CN": "\u4f18\u96c5\u732b",
+        "zh_TW": "\u512a\u96c5\u8c93"
+      }
     },
     "Sableye": {
-      "codename": "302"
+      "codename": "302",
+      "locale": {
+        "fr": "T\u00e9n\u00e9fix",
+        "de": "Zobiris",
+        "ko": "\uae5c\uae4c\ubbf8",
+        "ja": "\u30e4\u30df\u30e9\u30df",
+        "zh_CN": "\u52fe\u9b42\u773c",
+        "zh_TW": "\u52fe\u9b42\u773c"
+      }
     },
     "Mawile": {
-      "codename": "303"
+      "codename": "303",
+      "locale": {
+        "fr": "Mysdibule",
+        "de": "Flunkifer",
+        "ko": "\uc785\uce58\ud2b8",
+        "ja": "\u30af\u30c1\u30fc\u30c8",
+        "zh_CN": "\u5927\u5634\u5a03",
+        "zh_TW": "\u5927\u5634\u5a03"
+      }
     },
     "Aron": {
-      "codename": "304"
+      "codename": "304",
+      "locale": {
+        "fr": "Galekid",
+        "de": "Stollunior",
+        "ko": "\uac00\ubcf4\ub9ac",
+        "ja": "\u30b3\u30b3\u30c9\u30e9",
+        "zh_CN": "\u53ef\u53ef\u591a\u62c9",
+        "zh_TW": "\u53ef\u53ef\u591a\u62c9"
+      }
     },
     "Lairon": {
-      "codename": "305"
+      "codename": "305",
+      "locale": {
+        "fr": "Galegon",
+        "de": "Stollrak",
+        "ko": "\uac31\ub3c4\ub77c",
+        "ja": "\u30b3\u30c9\u30e9",
+        "zh_CN": "\u53ef\u591a\u62c9",
+        "zh_TW": "\u53ef\u591a\u62c9"
+      }
     },
     "Aggron": {
-      "codename": "306"
+      "codename": "306",
+      "locale": {
+        "fr": "Galeking",
+        "de": "Stolloss",
+        "ko": "\ubcf4\uc2a4\ub85c\ub77c",
+        "ja": "\u30dc\u30b9\u30b4\u30c9\u30e9",
+        "zh_CN": "\u6ce2\u58eb\u53ef\u591a\u62c9",
+        "zh_TW": "\u6ce2\u58eb\u53ef\u591a\u62c9"
+      }
     },
     "Meditite": {
-      "codename": "307"
+      "codename": "307",
+      "locale": {
+        "fr": "M\u00e9ditikka",
+        "de": "Meditie",
+        "ko": "\uc694\uac00\ub791",
+        "ja": "\u30a2\u30b5\u30ca\u30f3",
+        "zh_CN": "\u739b\u6c99\u90a3",
+        "zh_TW": "\u746a\u6c99\u90a3"
+      }
     },
     "Medicham": {
-      "codename": "308"
+      "codename": "308",
+      "locale": {
+        "fr": "Charmina",
+        "de": "Meditalis",
+        "ko": "\uc694\uac00\ub7a8",
+        "ja": "\u30c1\u30e3\u30fc\u30ec\u30e0",
+        "zh_CN": "\u6070\u96f7\u59c6",
+        "zh_TW": "\u6070\u96f7\u59c6"
+      }
     },
     "Electrike": {
-      "codename": "309"
+      "codename": "309",
+      "locale": {
+        "fr": "Dynavolt",
+        "de": "Frizelbliz",
+        "ko": "\uc36c\ub354\ub77c\uc774",
+        "ja": "\u30e9\u30af\u30e9\u30a4",
+        "zh_CN": "\u843d\u96f7\u517d",
+        "zh_TW": "\u843d\u96f7\u7378"
+      }
     },
     "Manectric": {
-      "codename": "310"
+      "codename": "310",
+      "locale": {
+        "fr": "\u00c9lecsprint",
+        "de": "Voltenso",
+        "ko": "\uc36c\ub354\ubcfc\ud2b8",
+        "ja": "\u30e9\u30a4\u30dc\u30eb\u30c8",
+        "zh_CN": "\u96f7\u7535\u517d",
+        "zh_TW": "\u96f7\u96fb\u7378"
+      }
     },
     "Plusle": {
-      "codename": "311"
+      "codename": "311",
+      "locale": {
+        "fr": "Posipi",
+        "de": "Plusle",
+        "ko": "\ud50c\ub7ec\uc2dc",
+        "ja": "\u30d7\u30e9\u30b9\u30eb",
+        "zh_CN": "\u6b63\u7535\u62cd\u62cd",
+        "zh_TW": "\u6b63\u96fb\u62cd\u62cd"
+      }
     },
     "Minun": {
-      "codename": "312"
+      "codename": "312",
+      "locale": {
+        "fr": "N\u00e9gapi",
+        "de": "Minun",
+        "ko": "\ub9c8\uc774\ub18d",
+        "ja": "\u30de\u30a4\u30ca\u30f3",
+        "zh_CN": "\u8d1f\u7535\u62cd\u62cd",
+        "zh_TW": "\u8ca0\u96fb\u62cd\u62cd"
+      }
     },
     "Volbeat": {
-      "codename": "313"
+      "codename": "313",
+      "locale": {
+        "fr": "Muciole",
+        "de": "Volbeat",
+        "ko": "\ubcfc\ube44\ud2b8",
+        "ja": "\u30d0\u30eb\u30d3\u30fc\u30c8",
+        "zh_CN": "\u7535\u8424\u866b",
+        "zh_TW": "\u96fb\u87a2\u87f2"
+      }
     },
     "Illumise": {
-      "codename": "314"
+      "codename": "314",
+      "locale": {
+        "fr": "Lumivole",
+        "de": "Illumise",
+        "ko": "\ub124\uc624\ube44\ud2b8",
+        "ja": "\u30a4\u30eb\u30df\u30fc\u30bc",
+        "zh_CN": "\u751c\u751c\u8424",
+        "zh_TW": "\u751c\u751c\u87a2"
+      }
     },
     "Roselia": {
-      "codename": "315"
+      "codename": "315",
+      "locale": {
+        "fr": "Ros\u00e9lia",
+        "de": "Roselia",
+        "ko": "\ub85c\uc824\ub9ac\uc544",
+        "ja": "\u30ed\u30bc\u30ea\u30a2",
+        "zh_CN": "\u6bd2\u8537\u8587",
+        "zh_TW": "\u6bd2\u8594\u8587"
+      }
     },
     "Gulpin": {
-      "codename": "316"
+      "codename": "316",
+      "locale": {
+        "fr": "Gloupti",
+        "de": "Schluppuck",
+        "ko": "\uaf34\uae4d\ubaac",
+        "ja": "\u30b4\u30af\u30ea\u30f3",
+        "zh_CN": "\u6eb6\u98df\u517d",
+        "zh_TW": "\u6eb6\u98df\u7378"
+      }
     },
     "Swalot": {
-      "codename": "317"
+      "codename": "317",
+      "locale": {
+        "fr": "Avaltout",
+        "de": "Schlukwech",
+        "ko": "\uafc0\uaebd\ubaac",
+        "ja": "\u30de\u30eb\u30ce\u30fc\u30e0",
+        "zh_CN": "\u541e\u98df\u517d",
+        "zh_TW": "\u541e\u98df\u7378"
+      }
     },
     "Carvanha": {
-      "codename": "318"
+      "codename": "318",
+      "locale": {
+        "fr": "Carvanha",
+        "de": "Kanivanha",
+        "ko": "\uc0e4\ud504\ub2c8\uc544",
+        "ja": "\u30ad\u30d0\u30cb\u30a2",
+        "zh_CN": "\u5229\u7259\u9c7c",
+        "zh_TW": "\u5229\u7259\u9b5a"
+      }
     },
     "Sharpedo": {
-      "codename": "319"
+      "codename": "319",
+      "locale": {
+        "fr": "Sharpedo",
+        "de": "Tohaido",
+        "ko": "\uc0e4\ud06c\ub2c8\uc544",
+        "ja": "\u30b5\u30e1\u30cf\u30c0\u30fc",
+        "zh_CN": "\u5de8\u7259\u9ca8",
+        "zh_TW": "\u5de8\u7259\u9bca"
+      }
     },
     "Wailmer": {
-      "codename": "320"
+      "codename": "320",
+      "locale": {
+        "fr": "Wailmer",
+        "de": "Wailmer",
+        "ko": "\uace0\ub798\uc655\uc790",
+        "ja": "\u30db\u30a8\u30eb\u30b3",
+        "zh_CN": "\u543c\u543c\u9cb8",
+        "zh_TW": "\u543c\u543c\u9be8"
+      }
     },
     "Wailord": {
-      "codename": "321"
+      "codename": "321",
+      "locale": {
+        "fr": "Wailord",
+        "de": "Wailord",
+        "ko": "\uace0\ub798\uc655",
+        "ja": "\u30db\u30a8\u30eb\u30aa\u30fc",
+        "zh_CN": "\u543c\u9cb8\u738b",
+        "zh_TW": "\u543c\u9be8\u738b"
+      }
     },
     "Numel": {
-      "codename": "322"
+      "codename": "322",
+      "locale": {
+        "fr": "Chamallot",
+        "de": "Camaub",
+        "ko": "\ub454\ud0c0",
+        "ja": "\u30c9\u30f3\u30e1\u30eb",
+        "zh_CN": "\u5446\u706b\u9a7c",
+        "zh_TW": "\u5446\u706b\u99dd"
+      }
     },
     "Camerupt": {
-      "codename": "323"
+      "codename": "323",
+      "locale": {
+        "fr": "Cam\u00e9rupt",
+        "de": "Camerupt",
+        "ko": "\ud3ed\ud0c0",
+        "ja": "\u30d0\u30af\u30fc\u30c0",
+        "zh_CN": "\u55b7\u706b\u9a7c",
+        "zh_TW": "\u5674\u706b\u99dd"
+      }
     },
     "Torkoal": {
-      "codename": "324"
+      "codename": "324",
+      "locale": {
+        "fr": "Chartor",
+        "de": "Qurtel",
+        "ko": "\ucf54\ud130\uc2a4",
+        "ja": "\u30b3\u30fc\u30bf\u30b9",
+        "zh_CN": "\u7164\u70ad\u9f9f",
+        "zh_TW": "\u7164\u70ad\u9f9c"
+      }
     },
     "Spoink": {
-      "codename": "325"
+      "codename": "325",
+      "locale": {
+        "fr": "Spoink",
+        "de": "Spoink",
+        "ko": "\ud53c\uadf8\uc810\ud504",
+        "ja": "\u30d0\u30cd\u30d6\u30fc",
+        "zh_CN": "\u8df3\u8df3\u732a",
+        "zh_TW": "\u8df3\u8df3\u8c6c"
+      }
     },
     "Grumpig": {
-      "codename": "326"
+      "codename": "326",
+      "locale": {
+        "fr": "Groret",
+        "de": "Groink",
+        "ko": "\ud53c\uadf8\ud0b9",
+        "ja": "\u30d6\u30fc\u30d4\u30c3\u30b0",
+        "zh_CN": "\u5657\u5657\u732a",
+        "zh_TW": "\u5657\u5657\u8c6c"
+      }
     },
     "Spinda": {
-      "codename": "327"
+      "codename": "327",
+      "locale": {
+        "fr": "Spinda",
+        "de": "Pandir",
+        "ko": "\uc5bc\ub8e8\uae30",
+        "ja": "\u30d1\u30c3\u30c1\u30fc\u30eb",
+        "zh_CN": "\u6643\u6643\u6591",
+        "zh_TW": "\u6643\u6643\u6591"
+      }
     },
     "Trapinch": {
-      "codename": "328"
+      "codename": "328",
+      "locale": {
+        "fr": "Kraknoix",
+        "de": "Knacklion",
+        "ko": "\ud1b1\uce58",
+        "ja": "\u30ca\u30c3\u30af\u30e9\u30fc",
+        "zh_CN": "\u5927\u989a\u8681",
+        "zh_TW": "\u5927\u984e\u87fb"
+      }
     },
     "Vibrava": {
-      "codename": "329"
+      "codename": "329",
+      "locale": {
+        "fr": "Vibraninf",
+        "de": "Vibrava",
+        "ko": "\ube44\ube0c\ub77c\ubc14",
+        "ja": "\u30d3\u30d6\u30e9\u30fc\u30d0",
+        "zh_CN": "\u8d85\u97f3\u6ce2\u5e7c\u866b",
+        "zh_TW": "\u8d85\u97f3\u6ce2\u5e7c\u87f2"
+      }
     },
     "Flygon": {
-      "codename": "330"
+      "codename": "330",
+      "locale": {
+        "fr": "Lib\u00e9gon",
+        "de": "Libelldra",
+        "ko": "\ud50c\ub77c\uc774\uace4",
+        "ja": "\u30d5\u30e9\u30a4\u30b4\u30f3",
+        "zh_CN": "\u6c99\u6f20\u873b\u8713",
+        "zh_TW": "\u6c99\u6f20\u873b\u8713"
+      }
     },
     "Cacnea": {
-      "codename": "331"
+      "codename": "331",
+      "locale": {
+        "fr": "Cacnea",
+        "de": "Tuska",
+        "ko": "\uc120\uc778\uc655",
+        "ja": "\u30b5\u30dc\u30cd\u30a2",
+        "zh_CN": "\u6c99\u6f20\u5948\u4e9a",
+        "zh_TW": "\u6c99\u6f20\u5948\u4e9e"
+      }
     },
     "Cacturne": {
-      "codename": "332"
+      "codename": "332",
+      "locale": {
+        "fr": "Cacturne",
+        "de": "Noktuska",
+        "ko": "\ubc24\uc120\uc778",
+        "ja": "\u30ce\u30af\u30bf\u30b9",
+        "zh_CN": "\u68a6\u6b4c\u5948\u4e9a",
+        "zh_TW": "\u5922\u6b4c\u5948\u4e9e"
+      }
     },
     "Swablu": {
-      "codename": "333"
+      "codename": "333",
+      "locale": {
+        "fr": "Tylton",
+        "de": "Wablu",
+        "ko": "\ud30c\ube44\ucf54",
+        "ja": "\u30c1\u30eb\u30c3\u30c8",
+        "zh_CN": "\u9752\u7ef5\u9e1f",
+        "zh_TW": "\u9752\u7dbf\u9ce5"
+      }
     },
     "Altaria": {
-      "codename": "334"
+      "codename": "334",
+      "locale": {
+        "fr": "Altaria",
+        "de": "Altaria",
+        "ko": "\ud30c\ube44\ucf54\ub9ac",
+        "ja": "\u30c1\u30eb\u30bf\u30ea\u30b9",
+        "zh_CN": "\u4e03\u5915\u9752\u9e1f",
+        "zh_TW": "\u4e03\u5915\u9752\u9ce5"
+      }
     },
     "Zangoose": {
-      "codename": "335"
+      "codename": "335",
+      "locale": {
+        "fr": "Mangriff",
+        "de": "Sengo",
+        "ko": "\uc7dd\uace0",
+        "ja": "\u30b6\u30f3\u30b0\u30fc\u30b9",
+        "zh_CN": "\u732b\u9f2c\u65a9",
+        "zh_TW": "\u8c93\u9f2c\u65ac"
+      }
     },
     "Seviper": {
-      "codename": "336"
+      "codename": "336",
+      "locale": {
+        "fr": "S\u00e9viper",
+        "de": "Vipitis",
+        "ko": "\uc138\ube44\ud37c",
+        "ja": "\u30cf\u30d6\u30cd\u30fc\u30af",
+        "zh_CN": "\u996d\u5319\u86c7",
+        "zh_TW": "\u98ef\u5319\u86c7"
+      }
     },
     "Lunatone": {
-      "codename": "337"
+      "codename": "337",
+      "locale": {
+        "fr": "S\u00e9l\u00e9roc",
+        "de": "Lunastein",
+        "ko": "\ub8e8\ub098\ud1a4",
+        "ja": "\u30eb\u30ca\u30c8\u30fc\u30f3",
+        "zh_CN": "\u6708\u77f3",
+        "zh_TW": "\u6708\u77f3"
+      }
     },
     "Solrock": {
-      "codename": "338"
+      "codename": "338",
+      "locale": {
+        "fr": "Solaroc",
+        "de": "Sonnfel",
+        "ko": "\uc194\ub85d",
+        "ja": "\u30bd\u30eb\u30ed\u30c3\u30af",
+        "zh_CN": "\u592a\u9633\u5ca9",
+        "zh_TW": "\u592a\u967d\u5ca9"
+      }
     },
     "Barboach": {
-      "codename": "339"
+      "codename": "339",
+      "locale": {
+        "fr": "Barloche",
+        "de": "Schmerbe",
+        "ko": "\ubbf8\uafb8\ub9ac",
+        "ja": "\u30c9\u30b8\u30e7\u30c3\u30c1",
+        "zh_CN": "\u6ce5\u6ce5\u9cc5",
+        "zh_TW": "\u6ce5\u6ce5\u9c0d"
+      }
     },
     "Whiscash": {
-      "codename": "340"
+      "codename": "340",
+      "locale": {
+        "fr": "Barbicha",
+        "de": "Welsar",
+        "ko": "\uba54\uae45",
+        "ja": "\u30ca\u30de\u30ba\u30f3",
+        "zh_CN": "\u9cb6\u9c7c\u738b",
+        "zh_TW": "\u9bf0\u9b5a\u738b"
+      }
     },
     "Corphish": {
-      "codename": "341"
+      "codename": "341",
+      "locale": {
+        "fr": "\u00c9crapince",
+        "de": "Krebscorps",
+        "ko": "\uac00\uc7ac\uad70",
+        "ja": "\u30d8\u30a4\u30ac\u30cb",
+        "zh_CN": "\u9f99\u867e\u5c0f\u5175",
+        "zh_TW": "\u9f8d\u8766\u5c0f\u5175"
+      }
     },
     "Crawdaunt": {
-      "codename": "342"
+      "codename": "342",
+      "locale": {
+        "fr": "Colhomard",
+        "de": "Krebutack",
+        "ko": "\uac00\uc7ac\uc7a5\uad70",
+        "ja": "\u30b7\u30b6\u30ea\u30ac\u30fc",
+        "zh_CN": "\u94c1\u87af\u9f99\u867e",
+        "zh_TW": "\u9435\u87af\u9f8d\u8766"
+      }
     },
     "Baltoy": {
-      "codename": "343"
+      "codename": "343",
+      "locale": {
+        "fr": "Balbuto",
+        "de": "Puppance",
+        "ko": "\uc624\ub69d\uad70",
+        "ja": "\u30e4\u30b8\u30ed\u30f3",
+        "zh_CN": "\u5929\u79e4\u5076",
+        "zh_TW": "\u5929\u79e4\u5076"
+      }
     },
     "Claydol": {
-      "codename": "344"
+      "codename": "344",
+      "locale": {
+        "fr": "Kaorine",
+        "de": "Lepumentas",
+        "ko": "\uc810\ud1a0\ub3c4\ub9ac",
+        "ja": "\u30cd\u30f3\u30c9\u30fc\u30eb",
+        "zh_CN": "\u5ff5\u529b\u571f\u5076",
+        "zh_TW": "\u5ff5\u529b\u571f\u5076"
+      }
     },
     "Lileep": {
-      "codename": "345"
+      "codename": "345",
+      "locale": {
+        "fr": "Lilia",
+        "de": "Liliep",
+        "ko": "\ub9b4\ub9c1",
+        "ja": "\u30ea\u30ea\u30fc\u30e9",
+        "zh_CN": "\u89e6\u624b\u767e\u5408",
+        "zh_TW": "\u89f8\u624b\u767e\u5408"
+      }
     },
     "Cradily": {
-      "codename": "346"
+      "codename": "346",
+      "locale": {
+        "fr": "Vacilys",
+        "de": "Wielie",
+        "ko": "\ub9b4\ub9ac\uc694",
+        "ja": "\u30e6\u30ec\u30a4\u30c9\u30eb",
+        "zh_CN": "\u6447\u7bee\u767e\u5408",
+        "zh_TW": "\u6416\u7c43\u767e\u5408"
+      }
     },
     "Anorith": {
-      "codename": "347"
+      "codename": "347",
+      "locale": {
+        "fr": "Anorith",
+        "de": "Anorith",
+        "ko": "\uc544\ub178\ub525\uc2a4",
+        "ja": "\u30a2\u30ce\u30d7\u30b9",
+        "zh_CN": "\u592a\u53e4\u7fbd\u866b",
+        "zh_TW": "\u592a\u53e4\u7fbd\u87f2"
+      }
     },
     "Armaldo": {
-      "codename": "348"
+      "codename": "348",
+      "locale": {
+        "fr": "Armaldo",
+        "de": "Armaldo",
+        "ko": "\uc544\ub9d0\ub3c4",
+        "ja": "\u30a2\u30fc\u30de\u30eb\u30c9",
+        "zh_CN": "\u592a\u53e4\u76d4\u7532",
+        "zh_TW": "\u592a\u53e4\u76d4\u7532"
+      }
     },
     "Feebas": {
-      "codename": "349"
+      "codename": "349",
+      "locale": {
+        "fr": "Barpau",
+        "de": "Barschwa",
+        "ko": "\ube48\ud2f0\ub098",
+        "ja": "\u30d2\u30f3\u30d0\u30b9",
+        "zh_CN": "\u7b28\u7b28\u9c7c",
+        "zh_TW": "\u7b28\u7b28\u9b5a"
+      }
     },
     "Milotic": {
-      "codename": "350"
+      "codename": "350",
+      "locale": {
+        "fr": "Milobellus",
+        "de": "Milotic",
+        "ko": "\ubc00\ub85c\ud2f1",
+        "ja": "\u30df\u30ed\u30ab\u30ed\u30b9",
+        "zh_CN": "\u7f8e\u7eb3\u65af",
+        "zh_TW": "\u7f8e\u7d0d\u65af"
+      }
     },
     "Castform": {
-      "codename": "351"
+      "codename": "351",
+      "locale": {
+        "fr": "Morph\u00e9o",
+        "de": "Formeo",
+        "ko": "\uce90\uc2a4\ud401",
+        "ja": "\u30dd\u30ef\u30eb\u30f3",
+        "zh_CN": "\u6f02\u6d6e\u6ce1\u6ce1",
+        "zh_TW": "\u6f02\u6d6e\u6ce1\u6ce1"
+      }
     },
     "Kecleon": {
-      "codename": "352"
+      "codename": "352",
+      "locale": {
+        "fr": "Kecleon",
+        "de": "Kecleon",
+        "ko": "\ucf08\ub9ac\ubaac",
+        "ja": "\u30ab\u30af\u30ec\u30aa\u30f3",
+        "zh_CN": "\u53d8\u9690\u9f99",
+        "zh_TW": "\u8b8a\u96b1\u9f8d"
+      }
     },
     "Shuppet": {
-      "codename": "353"
+      "codename": "353",
+      "locale": {
+        "fr": "Polichombr",
+        "de": "Shuppet",
+        "ko": "\uc5b4\ub460\ub300\uc2e0",
+        "ja": "\u30ab\u30b2\u30dc\u30a6\u30ba",
+        "zh_CN": "\u6028\u5f71\u5a03\u5a03",
+        "zh_TW": "\u6028\u5f71\u5a03\u5a03"
+      }
     },
     "Banette": {
-      "codename": "354"
+      "codename": "354",
+      "locale": {
+        "fr": "Branette",
+        "de": "Banette",
+        "ko": "\ub2e4\ud06c\ud3ab",
+        "ja": "\u30b8\u30e5\u30da\u30c3\u30bf",
+        "zh_CN": "\u8bc5\u5492\u5a03\u5a03",
+        "zh_TW": "\u8a5b\u5492\u5a03\u5a03"
+      }
     },
     "Duskull": {
-      "codename": "355"
+      "codename": "355",
+      "locale": {
+        "fr": "Skel\u00e9nox",
+        "de": "Zwirrlicht",
+        "ko": "\ud574\uace8\ubabd",
+        "ja": "\u30e8\u30de\u30ef\u30eb",
+        "zh_CN": "\u591c\u9ab7\u9885",
+        "zh_TW": "\u591c\u9ab7\u9871"
+      }
     },
     "Dusclops": {
-      "codename": "356"
+      "codename": "356",
+      "locale": {
+        "fr": "T\u00e9raclope",
+        "de": "Zwirrklop",
+        "ko": "\ubbf8\ub77c\ubabd",
+        "ja": "\u30b5\u30de\u30e8\u30fc\u30eb",
+        "zh_CN": "\u591c\u5de8\u4eba",
+        "zh_TW": "\u591c\u5de8\u4eba"
+      }
     },
     "Tropius": {
-      "codename": "357"
+      "codename": "357",
+      "locale": {
+        "fr": "Tropius",
+        "de": "Tropius",
+        "ko": "\ud2b8\ub85c\ud53c\uc6b0\uc2a4",
+        "ja": "\u30c8\u30ed\u30d4\u30a6\u30b9",
+        "zh_CN": "\u70ed\u5e26\u9f99",
+        "zh_TW": "\u71b1\u5e36\u9f8d"
+      }
     },
     "Chimecho": {
-      "codename": "358"
+      "codename": "358",
+      "locale": {
+        "fr": "\u00c9oko",
+        "de": "Palimpalim",
+        "ko": "\uce58\ub801",
+        "ja": "\u30c1\u30ea\u30fc\u30f3",
+        "zh_CN": "\u98ce\u94c3\u94c3",
+        "zh_TW": "\u98a8\u9234\u9234"
+      }
     },
     "Absol": {
-      "codename": "359"
+      "codename": "359",
+      "locale": {
+        "fr": "Absol",
+        "de": "Absol",
+        "ko": "\uc571\uc194",
+        "ja": "\u30a2\u30d6\u30bd\u30eb",
+        "zh_CN": "\u963f\u52c3\u68ad\u9c81",
+        "zh_TW": "\u963f\u52c3\u68ad\u9b6f"
+      }
     },
     "Wynaut": {
-      "codename": "360"
+      "codename": "360",
+      "locale": {
+        "fr": "Ok\u00e9ok\u00e9",
+        "de": "Isso",
+        "ko": "\ub9c8\uc790",
+        "ja": "\u30bd\u30fc\u30ca\u30ce",
+        "zh_CN": "\u5c0f\u679c\u7136",
+        "zh_TW": "\u5c0f\u679c\u7136"
+      }
     },
     "Snorunt": {
-      "codename": "361"
+      "codename": "361",
+      "locale": {
+        "fr": "Stalgamin",
+        "de": "Schneppke",
+        "ko": "\ub208\uaf2c\ub9c8",
+        "ja": "\u30e6\u30ad\u30ef\u30e9\u30b7",
+        "zh_CN": "\u96ea\u7ae5\u5b50",
+        "zh_TW": "\u96ea\u7ae5\u5b50"
+      }
     },
     "Glalie": {
-      "codename": "362"
+      "codename": "362",
+      "locale": {
+        "fr": "Oniglali",
+        "de": "Firnontor",
+        "ko": "\uc5bc\uc74c\uadc0\uc2e0",
+        "ja": "\u30aa\u30cb\u30b4\u30fc\u30ea",
+        "zh_CN": "\u51b0\u9b3c\u62a4",
+        "zh_TW": "\u51b0\u9b3c\u8b77"
+      }
     },
     "Spheal": {
-      "codename": "363"
+      "codename": "363",
+      "locale": {
+        "fr": "Obalie",
+        "de": "Seemops",
+        "ko": "\ub300\uad74\ub808\uc624",
+        "ja": "\u30bf\u30de\u30b6\u30e9\u30b7",
+        "zh_CN": "\u6d77\u8c79\u7403",
+        "zh_TW": "\u6d77\u8c79\u7403"
+      }
     },
     "Sealeo": {
-      "codename": "364"
+      "codename": "364",
+      "locale": {
+        "fr": "Phogleur",
+        "de": "Seejong",
+        "ko": "\uc528\ub808\uc624",
+        "ja": "\u30c8\u30c9\u30b0\u30e9\u30fc",
+        "zh_CN": "\u6d77\u9b54\u72ee",
+        "zh_TW": "\u6d77\u9b54\u7345"
+      }
     },
     "Walrein": {
-      "codename": "365"
+      "codename": "365",
+      "locale": {
+        "fr": "Kaimorse",
+        "de": "Walraisa",
+        "ko": "\uc528\uce74\uc774\uc800",
+        "ja": "\u30c8\u30c9\u30bc\u30eb\u30ac",
+        "zh_CN": "\u5e1d\u7259\u6d77\u72ee",
+        "zh_TW": "\u5e1d\u7259\u6d77\u7345"
+      }
     },
     "Clamperl": {
-      "codename": "366"
+      "codename": "366",
+      "locale": {
+        "fr": "Coquiperl",
+        "de": "Perlu",
+        "ko": "\uc9c4\uc8fc\ubabd",
+        "ja": "\u30d1\u30fc\u30eb\u30eb",
+        "zh_CN": "\u73cd\u73e0\u8d1d",
+        "zh_TW": "\u73cd\u73e0\u8c9d"
+      }
     },
     "Huntail": {
-      "codename": "367"
+      "codename": "367",
+      "locale": {
+        "fr": "Serpang",
+        "de": "Aalabyss",
+        "ko": "\ud5cc\ud14c\uc77c",
+        "ja": "\u30cf\u30f3\u30c6\u30fc\u30eb",
+        "zh_CN": "\u730e\u6591\u9c7c",
+        "zh_TW": "\u7375\u6591\u9b5a"
+      }
     },
     "Gorebyss": {
-      "codename": "368"
+      "codename": "368",
+      "locale": {
+        "fr": "Rosabyss",
+        "de": "Saganabyss",
+        "ko": "\ubd84\ud64d\uc7a5\uc774",
+        "ja": "\u30b5\u30af\u30e9\u30d3\u30b9",
+        "zh_CN": "\u6a31\u82b1\u9c7c",
+        "zh_TW": "\u6afb\u82b1\u9b5a"
+      }
     },
     "Relicanth": {
-      "codename": "369"
+      "codename": "369",
+      "locale": {
+        "fr": "Relicanth",
+        "de": "Relicanth",
+        "ko": "\uc2dc\ub77c\uce78",
+        "ja": "\u30b8\u30fc\u30e9\u30f3\u30b9",
+        "zh_CN": "\u53e4\u7a7a\u68d8\u9c7c",
+        "zh_TW": "\u53e4\u7a7a\u68d8\u9b5a"
+      }
     },
     "Luvdisc": {
-      "codename": "370"
+      "codename": "370",
+      "locale": {
+        "fr": "Lovdisc",
+        "de": "Liebiskus",
+        "ko": "\uc0ac\ub791\ub3d9\uc774",
+        "ja": "\u30e9\u30d6\u30ab\u30b9",
+        "zh_CN": "\u7231\u5fc3\u9c7c",
+        "zh_TW": "\u611b\u5fc3\u9b5a"
+      }
     },
     "Bagon": {
-      "codename": "371"
+      "codename": "371",
+      "locale": {
+        "fr": "Draby",
+        "de": "Kindwurm",
+        "ko": "\uc544\uacf5\uc774",
+        "ja": "\u30bf\u30c4\u30d9\u30a4",
+        "zh_CN": "\u5b9d\u8d1d\u9f99",
+        "zh_TW": "\u5bf6\u8c9d\u9f8d"
+      }
     },
     "Shelgon": {
-      "codename": "372"
+      "codename": "372",
+      "locale": {
+        "fr": "Drackhaus",
+        "de": "Draschel",
+        "ko": "\uc258\uace4",
+        "ja": "\u30b3\u30e2\u30eb\u30fc",
+        "zh_CN": "\u7532\u58f3\u9f99",
+        "zh_TW": "\u7532\u6bbc\u9f8d"
+      }
     },
     "Salamence": {
-      "codename": "373"
+      "codename": "373",
+      "locale": {
+        "fr": "Drattak",
+        "de": "Brutalanda",
+        "ko": "\ubcf4\ub9cc\ub2e4",
+        "ja": "\u30dc\u30fc\u30de\u30f3\u30c0",
+        "zh_CN": "\u66b4\u98de\u9f99",
+        "zh_TW": "\u66b4\u98db\u9f8d"
+      }
     },
     "Beldum": {
-      "codename": "374"
+      "codename": "374",
+      "locale": {
+        "fr": "Terhal",
+        "de": "Tanhel",
+        "ko": "\uba54\ud0d5",
+        "ja": "\u30c0\u30f3\u30d0\u30eb",
+        "zh_CN": "\u94c1\u54d1\u94c3",
+        "zh_TW": "\u9435\u555e\u9234"
+      }
     },
     "Metang": {
-      "codename": "375"
+      "codename": "375",
+      "locale": {
+        "fr": "M\u00e9tang",
+        "de": "Metang",
+        "ko": "\uba54\ud0d5\uad6c",
+        "ja": "\u30e1\u30bf\u30f3\u30b0",
+        "zh_CN": "\u91d1\u5c5e\u602a",
+        "zh_TW": "\u91d1\u5c6c\u602a"
+      }
     },
     "Metagross": {
-      "codename": "376"
+      "codename": "376",
+      "locale": {
+        "fr": "M\u00e9talosse",
+        "de": "Metagross",
+        "ko": "\uba54\ud0c0\uadf8\ub85c\uc2a4",
+        "ja": "\u30e1\u30bf\u30b0\u30ed\u30b9",
+        "zh_CN": "\u5de8\u91d1\u602a",
+        "zh_TW": "\u5de8\u91d1\u602a"
+      }
     },
     "Regirock": {
-      "codename": "377"
+      "codename": "377",
+      "locale": {
+        "fr": "Regirock",
+        "de": "Regirock",
+        "ko": "\ub808\uc9c0\ub77d",
+        "ja": "\u30ec\u30b8\u30ed\u30c3\u30af",
+        "zh_CN": "\u96f7\u5409\u6d1b\u514b",
+        "zh_TW": "\u96f7\u5409\u6d1b\u514b"
+      }
     },
     "Regice": {
-      "codename": "378"
+      "codename": "378",
+      "locale": {
+        "fr": "Regice",
+        "de": "Regice",
+        "ko": "\ub808\uc9c0\uc544\uc774\uc2a4",
+        "ja": "\u30ec\u30b8\u30a2\u30a4\u30b9",
+        "zh_CN": "\u96f7\u5409\u827e\u65af",
+        "zh_TW": "\u96f7\u5409\u827e\u65af"
+      }
     },
     "Registeel": {
-      "codename": "379"
+      "codename": "379",
+      "locale": {
+        "fr": "Registeel",
+        "de": "Registeel",
+        "ko": "\ub808\uc9c0\uc2a4\ud2f8",
+        "ja": "\u30ec\u30b8\u30b9\u30c1\u30eb",
+        "zh_CN": "\u96f7\u5409\u65af\u5947\u9c81",
+        "zh_TW": "\u96f7\u5409\u65af\u5947\u9b6f"
+      }
     },
     "Latias": {
-      "codename": "380"
+      "codename": "380",
+      "locale": {
+        "fr": "Latias",
+        "de": "Latias",
+        "ko": "\ub77c\ud2f0\uc544\uc2a4",
+        "ja": "\u30e9\u30c6\u30a3\u30a2\u30b9",
+        "zh_CN": "\u62c9\u5e1d\u4e9a\u65af",
+        "zh_TW": "\u62c9\u5e1d\u4e9e\u65af"
+      }
     },
     "Latios": {
-      "codename": "381"
+      "codename": "381",
+      "locale": {
+        "fr": "Latios",
+        "de": "Latios",
+        "ko": "\ub77c\ud2f0\uc624\uc2a4",
+        "ja": "\u30e9\u30c6\u30a3\u30aa\u30b9",
+        "zh_CN": "\u62c9\u5e1d\u6b27\u65af",
+        "zh_TW": "\u62c9\u5e1d\u6b50\u65af"
+      }
     },
     "Kyogre": {
-      "codename": "382"
+      "codename": "382",
+      "locale": {
+        "fr": "Kyogre",
+        "de": "Kyogre",
+        "ko": "\uac00\uc774\uc624\uac00",
+        "ja": "\u30ab\u30a4\u30aa\u30fc\u30ac",
+        "zh_CN": "\u76d6\u6b27\u5361",
+        "zh_TW": "\u84cb\u6b50\u5361"
+      }
     },
     "Groudon": {
-      "codename": "383"
+      "codename": "383",
+      "locale": {
+        "fr": "Groudon",
+        "de": "Groudon",
+        "ko": "\uadf8\ub780\ub3c8",
+        "ja": "\u30b0\u30e9\u30fc\u30c9\u30f3",
+        "zh_CN": "\u56fa\u62c9\u591a",
+        "zh_TW": "\u56fa\u62c9\u591a"
+      }
     },
     "Rayquaza": {
-      "codename": "384"
+      "codename": "384",
+      "locale": {
+        "fr": "Rayquaza",
+        "de": "Rayquaza",
+        "ko": "\ub808\ucfe0\uc7c8",
+        "ja": "\u30ec\u30c3\u30af\u30a6\u30b6",
+        "zh_CN": "\u70c8\u7a7a\u5750",
+        "zh_TW": "\u70c8\u7a7a\u5750"
+      }
     },
     "Jirachi": {
-      "codename": "385"
+      "codename": "385",
+      "locale": {
+        "fr": "Jirachi",
+        "de": "Jirachi",
+        "ko": "\uc9c0\ub77c\uce58",
+        "ja": "\u30b8\u30e9\u30fc\u30c1",
+        "zh_CN": "\u57fa\u62c9\u7948",
+        "zh_TW": "\u57fa\u62c9\u7948"
+      }
     },
     "Deoxys": {
-      "codename": "386"
+      "codename": "386",
+      "locale": {
+        "fr": "Deoxys",
+        "de": "Deoxys",
+        "ko": "\ud14c\uc624\ud0a4\uc2a4",
+        "ja": "\u30c7\u30aa\u30ad\u30b7\u30b9",
+        "zh_CN": "\u4ee3\u6b27\u5947\u5e0c\u65af",
+        "zh_TW": "\u4ee3\u6b50\u5947\u5e0c\u65af"
+      }
     },
     "Turtwig": {
-      "codename": "387"
+      "codename": "387",
+      "locale": {
+        "fr": "Tortipouss",
+        "de": "Chelast",
+        "ko": "\ubaa8\ubd80\uae30",
+        "ja": "\u30ca\u30a8\u30c8\u30eb",
+        "zh_CN": "\u8349\u82d7\u9f9f",
+        "zh_TW": "\u8349\u82d7\u9f9c"
+      }
     },
     "Grotle": {
-      "codename": "388"
+      "codename": "388",
+      "locale": {
+        "fr": "Boskara",
+        "de": "Chelcarain",
+        "ko": "\uc218\ud480\ubd80\uae30",
+        "ja": "\u30cf\u30e4\u30b7\u30ac\u30e1",
+        "zh_CN": "\u6811\u6797\u9f9f",
+        "zh_TW": "\u6a39\u6797\u9f9c"
+      }
     },
     "Torterra": {
-      "codename": "389"
+      "codename": "389",
+      "locale": {
+        "fr": "Torterra",
+        "de": "Chelterrar",
+        "ko": "\ud1a0\ub300\ubd80\uae30",
+        "ja": "\u30c9\u30c0\u30a4\u30c8\u30b9",
+        "zh_CN": "\u571f\u53f0\u9f9f",
+        "zh_TW": "\u571f\u53f0\u9f9c"
+      }
     },
     "Chimchar": {
-      "codename": "390"
+      "codename": "390",
+      "locale": {
+        "fr": "Ouisticram",
+        "de": "Panflam",
+        "ko": "\ubd88\uaf43\uc22d\uc774",
+        "ja": "\u30d2\u30b3\u30b6\u30eb",
+        "zh_CN": "\u5c0f\u706b\u7130\u7334",
+        "zh_TW": "\u5c0f\u706b\u7130\u7334"
+      }
     },
     "Monferno": {
-      "codename": "391"
+      "codename": "391",
+      "locale": {
+        "fr": "Chimpenfeu",
+        "de": "Panpyro",
+        "ko": "\ud30c\uc774\uc22d\uc774",
+        "ja": "\u30e2\u30a6\u30ab\u30b6\u30eb",
+        "zh_CN": "\u731b\u706b\u7334",
+        "zh_TW": "\u731b\u706b\u7334"
+      }
     },
     "Infernape": {
-      "codename": "392"
+      "codename": "392",
+      "locale": {
+        "fr": "Simiabraz",
+        "de": "Panferno",
+        "ko": "\ucd08\uc5fc\ubabd",
+        "ja": "\u30b4\u30a6\u30ab\u30b6\u30eb",
+        "zh_CN": "\u70c8\u7130\u7334",
+        "zh_TW": "\u70c8\u7130\u7334"
+      }
     },
     "Piplup": {
-      "codename": "393"
+      "codename": "393",
+      "locale": {
+        "fr": "Tiplouf",
+        "de": "Plinfa",
+        "ko": "\ud33d\ub3c4\ub9ac",
+        "ja": "\u30dd\u30c3\u30c1\u30e3\u30de",
+        "zh_CN": "\u6ce2\u52a0\u66fc",
+        "zh_TW": "\u6ce2\u52a0\u66fc"
+      }
     },
     "Prinplup": {
-      "codename": "394"
+      "codename": "394",
+      "locale": {
+        "fr": "Prinplouf",
+        "de": "Pliprin",
+        "ko": "\ud33d\ud0dc\uc790",
+        "ja": "\u30dd\u30c3\u30bf\u30a4\u30b7",
+        "zh_CN": "\u6ce2\u7687\u5b50",
+        "zh_TW": "\u6ce2\u7687\u5b50"
+      }
     },
     "Empoleon": {
-      "codename": "395"
+      "codename": "395",
+      "locale": {
+        "fr": "Pingol\u00e9on",
+        "de": "Impoleon",
+        "ko": "\uc5e0\ud398\ub974\ud2b8",
+        "ja": "\u30a8\u30f3\u30da\u30eb\u30c8",
+        "zh_CN": "\u5e1d\u738b\u62ff\u6ce2",
+        "zh_TW": "\u5e1d\u738b\u62ff\u6ce2"
+      }
     },
     "Starly": {
-      "codename": "396"
+      "codename": "396",
+      "locale": {
+        "fr": "\u00c9tourmi",
+        "de": "Staralili",
+        "ko": "\ucc0c\ub974\uaf2c",
+        "ja": "\u30e0\u30c3\u30af\u30eb",
+        "zh_CN": "\u59c6\u514b\u513f",
+        "zh_TW": "\u59c6\u514b\u5152"
+      }
     },
     "Staravia": {
-      "codename": "397"
+      "codename": "397",
+      "locale": {
+        "fr": "\u00c9tourvol",
+        "de": "Staravia",
+        "ko": "\ucc0c\ub974\ubc84\ub4dc",
+        "ja": "\u30e0\u30af\u30d0\u30fc\u30c9",
+        "zh_CN": "\u59c6\u514b\u9e1f",
+        "zh_TW": "\u59c6\u514b\u9ce5"
+      }
     },
     "Staraptor": {
-      "codename": "398"
+      "codename": "398",
+      "locale": {
+        "fr": "\u00c9touraptor",
+        "de": "Staraptor",
+        "ko": "\ucc0c\ub974\ud638\ud06c",
+        "ja": "\u30e0\u30af\u30db\u30fc\u30af",
+        "zh_CN": "\u59c6\u514b\u9e70",
+        "zh_TW": "\u59c6\u514b\u9df9"
+      }
     },
     "Bidoof": {
-      "codename": "399"
+      "codename": "399",
+      "locale": {
+        "fr": "Keunotor",
+        "de": "Bidiza",
+        "ko": "\ube44\ubc84\ub2c8",
+        "ja": "\u30d3\u30c3\u30d1",
+        "zh_CN": "\u5927\u7259\u72f8",
+        "zh_TW": "\u5927\u7259\u72f8"
+      }
     },
     "Bibarel": {
-      "codename": "400"
+      "codename": "400",
+      "locale": {
+        "fr": "Castorno",
+        "de": "Bidifas",
+        "ko": "\ube44\ubc84\ud1b5",
+        "ja": "\u30d3\u30fc\u30c0\u30eb",
+        "zh_CN": "\u5927\u5c3e\u72f8",
+        "zh_TW": "\u5927\u5c3e\u72f8"
+      }
     },
     "Kricketot": {
-      "codename": "401"
+      "codename": "401",
+      "locale": {
+        "fr": "Crikzik",
+        "de": "Zirpurze",
+        "ko": "\uadc0\ub6a4\ub69c\uae30",
+        "ja": "\u30b3\u30ed\u30dc\u30fc\u30b7",
+        "zh_CN": "\u5706\u6cd5\u5e08",
+        "zh_TW": "\u5713\u6cd5\u5e2b"
+      }
     },
     "Kricketune": {
-      "codename": "402"
+      "codename": "402",
+      "locale": {
+        "fr": "M\u00e9lokrik",
+        "de": "Zirpeise",
+        "ko": "\uadc0\ub6a4\ud1a1\ud06c",
+        "ja": "\u30b3\u30ed\u30c8\u30c3\u30af",
+        "zh_CN": "\u97f3\u7bb1\u87c0",
+        "zh_TW": "\u97f3\u7bb1\u87c0"
+      }
     },
     "Shinx": {
-      "codename": "403"
+      "codename": "403",
+      "locale": {
+        "fr": "Lixy",
+        "de": "Sheinux",
+        "ko": "\uaf2c\ub9c1\ud06c",
+        "ja": "\u30b3\u30ea\u30f3\u30af",
+        "zh_CN": "\u5c0f\u732b\u602a",
+        "zh_TW": "\u5c0f\u8c93\u602a"
+      }
     },
     "Luxio": {
-      "codename": "404"
+      "codename": "404",
+      "locale": {
+        "fr": "Luxio",
+        "de": "Luxio",
+        "ko": "\ub7ed\uc2dc\uc624",
+        "ja": "\u30eb\u30af\u30b7\u30aa",
+        "zh_CN": "\u52d2\u514b\u732b",
+        "zh_TW": "\u52d2\u514b\u8c93"
+      }
     },
     "Luxray": {
-      "codename": "405"
+      "codename": "405",
+      "locale": {
+        "fr": "Luxray",
+        "de": "Luxtra",
+        "ko": "\ub80c\ud2b8\ub77c",
+        "ja": "\u30ec\u30f3\u30c8\u30e9\u30fc",
+        "zh_CN": "\u4f26\u7434\u732b",
+        "zh_TW": "\u502b\u7434\u8c93"
+      }
     },
     "Budew": {
-      "codename": "406"
+      "codename": "406",
+      "locale": {
+        "fr": "Rozbouton",
+        "de": "Knospi",
+        "ko": "\uaf2c\ubabd\uc6b8",
+        "ja": "\u30b9\u30dc\u30df\u30fc",
+        "zh_CN": "\u542b\u7f9e\u82de",
+        "zh_TW": "\u542b\u7f9e\u82de"
+      }
     },
     "Roserade": {
-      "codename": "407"
+      "codename": "407",
+      "locale": {
+        "fr": "Roserade",
+        "de": "Roserade",
+        "ko": "\ub85c\uc988\ub808\uc774\ub4dc",
+        "ja": "\u30ed\u30ba\u30ec\u30a4\u30c9",
+        "zh_CN": "\u7f57\u4e1d\u96f7\u6735",
+        "zh_TW": "\u7f85\u7d72\u96f7\u6735"
+      }
     },
     "Cranidos": {
-      "codename": "408"
+      "codename": "408",
+      "locale": {
+        "fr": "Kranidos",
+        "de": "Koknodon",
+        "ko": "\ub450\uac1c\ub3c4\uc2a4",
+        "ja": "\u30ba\u30ac\u30a4\u30c9\u30b9",
+        "zh_CN": "\u5934\u76d6\u9f99",
+        "zh_TW": "\u982d\u84cb\u9f8d"
+      }
     },
     "Rampardos": {
-      "codename": "409"
+      "codename": "409",
+      "locale": {
+        "fr": "Charkos",
+        "de": "Rameidon",
+        "ko": "\ub7a8\ud384\ub4dc",
+        "ja": "\u30e9\u30e0\u30d1\u30eb\u30c9",
+        "zh_CN": "\u6218\u69cc\u9f99",
+        "zh_TW": "\u6230\u69cc\u9f8d"
+      }
     },
     "Shieldon": {
-      "codename": "410"
+      "codename": "410",
+      "locale": {
+        "fr": "Dinoclier",
+        "de": "Schilterus",
+        "ko": "\ubc29\ud328\ud1b1\uc2a4",
+        "ja": "\u30bf\u30c6\u30c8\u30d7\u30b9",
+        "zh_CN": "\u76fe\u7532\u9f99",
+        "zh_TW": "\u76fe\u7532\u9f8d"
+      }
     },
     "Bastiodon": {
-      "codename": "411"
+      "codename": "411",
+      "locale": {
+        "fr": "Bastiodon",
+        "de": "Bollterus",
+        "ko": "\ubc14\ub9ac\ud1b1\uc2a4",
+        "ja": "\u30c8\u30ea\u30c7\u30d7\u30b9",
+        "zh_CN": "\u62a4\u57ce\u9f99",
+        "zh_TW": "\u8b77\u57ce\u9f8d"
+      }
     },
     "Burmy": {
-      "codename": "412"
+      "codename": "412",
+      "locale": {
+        "fr": "Cheniti",
+        "de": "Burmy",
+        "ko": "\ub3c4\ub871\ucda9\uc774",
+        "ja": "\u30df\u30ce\u30e0\u30c3\u30c1",
+        "zh_CN": "\u7ed3\u8349\u513f",
+        "zh_TW": "\u7d50\u8349\u5152"
+      }
     },
     "Wormadam": {
-      "codename": "413"
+      "codename": "413",
+      "locale": {
+        "fr": "Cheniselle",
+        "de": "Burmadame",
+        "ko": "\ub3c4\ub871\ub9c8\ub2f4",
+        "ja": "\u30df\u30ce\u30de\u30c0\u30e0",
+        "zh_CN": "\u7ed3\u8349\u8d35\u5987",
+        "zh_TW": "\u7d50\u8349\u8cb4\u5a66"
+      }
     },
     "Mothim": {
-      "codename": "414"
+      "codename": "414",
+      "locale": {
+        "fr": "Papilord",
+        "de": "Moterpel",
+        "ko": "\ub098\uba54\uc77c",
+        "ja": "\u30ac\u30fc\u30e1\u30a4\u30eb",
+        "zh_CN": "\u7ec5\u58eb\u86fe",
+        "zh_TW": "\u7d33\u58eb\u86fe"
+      }
     },
     "Combee": {
-      "codename": "415"
+      "codename": "415",
+      "locale": {
+        "fr": "Apitrini",
+        "de": "Wadribie",
+        "ko": "\uc138\uafc0\ubc84\ub9ac",
+        "ja": "\u30df\u30c4\u30cf\u30cb\u30fc",
+        "zh_CN": "\u4e09\u871c\u8702",
+        "zh_TW": "\u4e09\u871c\u8702"
+      }
     },
     "Vespiquen": {
-      "codename": "416"
+      "codename": "416",
+      "locale": {
+        "fr": "Apireine",
+        "de": "Honweisel",
+        "ko": "\ube44\ud038",
+        "ja": "\u30d3\u30fc\u30af\u30a4\u30f3",
+        "zh_CN": "\u8702\u540e",
+        "zh_TW": "\u8702\u540e"
+      }
     },
     "Pachirisu": {
-      "codename": "417"
+      "codename": "417",
+      "locale": {
+        "fr": "Pachirisu",
+        "de": "Pachirisu",
+        "ko": "\ud30c\uce58\ub9ac\uc2a4",
+        "ja": "\u30d1\u30c1\u30ea\u30b9",
+        "zh_CN": "\u5e15\u5947\u5229\u5179",
+        "zh_TW": "\u5e15\u5947\u5229\u8332"
+      }
     },
     "Buizel": {
-      "codename": "418"
+      "codename": "418",
+      "locale": {
+        "fr": "Must\u00e9bou\u00e9e",
+        "de": "Bamelin",
+        "ko": "\ube0c\uc774\uc824",
+        "ja": "\u30d6\u30a4\u30bc\u30eb",
+        "zh_CN": "\u6cf3\u6c14\u9f2c",
+        "zh_TW": "\u6cf3\u6c23\u9f2c"
+      }
     },
     "Floatzel": {
-      "codename": "419"
+      "codename": "419",
+      "locale": {
+        "fr": "Must\u00e9flott",
+        "de": "Bojelin",
+        "ko": "\ud50c\ub85c\uc824",
+        "ja": "\u30d5\u30ed\u30fc\u30bc\u30eb",
+        "zh_CN": "\u6d6e\u6f5c\u9f2c",
+        "zh_TW": "\u6d6e\u6f5b\u9f2c"
+      }
     },
     "Cherubi": {
-      "codename": "420"
+      "codename": "420",
+      "locale": {
+        "fr": "Ceribou",
+        "de": "Kikugi",
+        "ko": "\uccb4\ub9ac\ubc84",
+        "ja": "\u30c1\u30a7\u30ea\u30f3\u30dc",
+        "zh_CN": "\u6a31\u82b1\u5b9d",
+        "zh_TW": "\u6afb\u82b1\u5bf6"
+      }
     },
     "Cherrim": {
-      "codename": "421"
+      "codename": "421",
+      "locale": {
+        "fr": "Ceriflor",
+        "de": "Kinoso",
+        "ko": "\uccb4\ub9ac\uaf2c",
+        "ja": "\u30c1\u30a7\u30ea\u30e0",
+        "zh_CN": "\u6a31\u82b1\u513f",
+        "zh_TW": "\u6afb\u82b1\u5152"
+      }
     },
     "Shellos": {
-      "codename": "422"
+      "codename": "422",
+      "locale": {
+        "fr": "Sancoki",
+        "de": "Schalellos",
+        "ko": "\uae5d\uc9c8\ubb34",
+        "ja": "\u30ab\u30e9\u30ca\u30af\u30b7",
+        "zh_CN": "\u65e0\u58f3\u6d77\u725b",
+        "zh_TW": "\u7121\u6bbc\u6d77\u725b"
+      }
     },
     "Gastrodon": {
-      "codename": "423"
+      "codename": "423",
+      "locale": {
+        "fr": "Tritosor",
+        "de": "Gastrodon",
+        "ko": "\ud2b8\ub9ac\ud1a0\ub3c8",
+        "ja": "\u30c8\u30ea\u30c8\u30c9\u30f3",
+        "zh_CN": "\u6d77\u725b\u517d",
+        "zh_TW": "\u6d77\u725b\u7378"
+      }
     },
     "Ambipom": {
-      "codename": "424"
+      "codename": "424",
+      "locale": {
+        "fr": "Capidextre",
+        "de": "Ambidiffel",
+        "ko": "\uac9f\ud578\ubcf4\uc22d",
+        "ja": "\u30a8\u30c6\u30dc\u30fc\u30b9",
+        "zh_CN": "\u53cc\u5c3e\u602a\u624b",
+        "zh_TW": "\u96d9\u5c3e\u602a\u624b"
+      }
     },
     "Drifloon": {
-      "codename": "425"
+      "codename": "425",
+      "locale": {
+        "fr": "Baudrive",
+        "de": "Driftlon",
+        "ko": "\ud754\ub4e4\ud48d\uc190",
+        "ja": "\u30d5\u30ef\u30f3\u30c6",
+        "zh_CN": "\u98d8\u98d8\u7403",
+        "zh_TW": "\u98c4\u98c4\u7403"
+      }
     },
     "Drifblim": {
-      "codename": "426"
+      "codename": "426",
+      "locale": {
+        "fr": "Grodrive",
+        "de": "Drifzepeli",
+        "ko": "\ub465\uc2e4\ub77c\uc774\ub4dc",
+        "ja": "\u30d5\u30ef\u30e9\u30a4\u30c9",
+        "zh_CN": "\u9644\u548c\u6c14\u7403",
+        "zh_TW": "\u9644\u548c\u6c23\u7403"
+      }
     },
     "Buneary": {
-      "codename": "427"
+      "codename": "427",
+      "locale": {
+        "fr": "Laporeille",
+        "de": "Haspiror",
+        "ko": "\uc774\uc5b4\ub864",
+        "ja": "\u30df\u30df\u30ed\u30eb",
+        "zh_CN": "\u5377\u5377\u8033",
+        "zh_TW": "\u6372\u6372\u8033"
+      }
     },
     "Lopunny": {
-      "codename": "428"
+      "codename": "428",
+      "locale": {
+        "fr": "Lockpin",
+        "de": "Schlapor",
+        "ko": "\uc774\uc5b4\ub86d",
+        "ja": "\u30df\u30df\u30ed\u30c3\u30d7",
+        "zh_CN": "\u957f\u8033\u5154",
+        "zh_TW": "\u9577\u8033\u5154"
+      }
     },
     "Mismagius": {
-      "codename": "429"
+      "codename": "429",
+      "locale": {
+        "fr": "Magir\u00eave",
+        "de": "Traunmagil",
+        "ko": "\ubb34\uc6b0\ub9c8\uc9c1",
+        "ja": "\u30e0\u30a6\u30de\u30fc\u30b8",
+        "zh_CN": "\u68a6\u5996\u9b54",
+        "zh_TW": "\u5922\u5996\u9b54"
+      }
     },
     "Honchkrow": {
-      "codename": "430"
+      "codename": "430",
+      "locale": {
+        "fr": "Corboss",
+        "de": "Kramshef",
+        "ko": "\ub3c8\ud06c\ub85c\uc6b0",
+        "ja": "\u30c9\u30f3\u30ab\u30e9\u30b9",
+        "zh_CN": "\u4e4c\u9e26\u5934\u5934",
+        "zh_TW": "\u70cf\u9d09\u982d\u982d"
+      }
     },
     "Glameow": {
-      "codename": "431"
+      "codename": "431",
+      "locale": {
+        "fr": "Chaglam",
+        "de": "Charmian",
+        "ko": "\ub098\uc639\ub9c8",
+        "ja": "\u30cb\u30e3\u30eb\u30de\u30fc",
+        "zh_CN": "\u9b45\u529b\u55b5",
+        "zh_TW": "\u9b45\u529b\u55b5"
+      }
     },
     "Purugly": {
-      "codename": "432"
+      "codename": "432",
+      "locale": {
+        "fr": "Chaffreux",
+        "de": "Shnurgarst",
+        "ko": "\ubaac\ub0e5\uc774",
+        "ja": "\u30d6\u30cb\u30e3\u30c3\u30c8",
+        "zh_CN": "\u4e1c\u65bd\u55b5",
+        "zh_TW": "\u6771\u65bd\u55b5"
+      }
     },
     "Chingling": {
-      "codename": "433"
+      "codename": "433",
+      "locale": {
+        "fr": "Korillon",
+        "de": "Klingplim",
+        "ko": "\ub791\ub538\ub791",
+        "ja": "\u30ea\u30fc\u30b7\u30e3\u30f3",
+        "zh_CN": "\u94c3\u94db\u54cd",
+        "zh_TW": "\u9234\u5679\u97ff"
+      }
     },
     "Stunky": {
-      "codename": "434"
+      "codename": "434",
+      "locale": {
+        "fr": "Moufouette",
+        "de": "Skunkapuh",
+        "ko": "\uc2a4\ucef9\ubfe1",
+        "ja": "\u30b9\u30ab\u30f3\u30d7\u30fc",
+        "zh_CN": "\u81ed\u9f2c\u5657",
+        "zh_TW": "\u81ed\u9f2c\u5657"
+      }
     },
     "Skuntank": {
-      "codename": "435"
+      "codename": "435",
+      "locale": {
+        "fr": "Moufflair",
+        "de": "Skunktank",
+        "ko": "\uc2a4\ucef9\ud0f1\ud06c",
+        "ja": "\u30b9\u30ab\u30bf\u30f3\u30af",
+        "zh_CN": "\u5766\u514b\u81ed\u9f2c",
+        "zh_TW": "\u5766\u514b\u81ed\u9f2c"
+      }
     },
     "Bronzor": {
-      "codename": "436"
+      "codename": "436",
+      "locale": {
+        "fr": "Arch\u00e9omire",
+        "de": "Bronzel",
+        "ko": "\ub3d9\ubbf8\ub7ec",
+        "ja": "\u30c9\u30fc\u30df\u30e9\u30fc",
+        "zh_CN": "\u94dc\u955c\u602a",
+        "zh_TW": "\u9285\u93e1\u602a"
+      }
     },
     "Bronzong": {
-      "codename": "437"
+      "codename": "437",
+      "locale": {
+        "fr": "Arch\u00e9odong",
+        "de": "Bronzong",
+        "ko": "\ub3d9\ud0c1\uad70",
+        "ja": "\u30c9\u30fc\u30bf\u30af\u30f3",
+        "zh_CN": "\u9752\u94dc\u949f",
+        "zh_TW": "\u9752\u9285\u9418"
+      }
     },
     "Bonsly": {
-      "codename": "438"
+      "codename": "438",
+      "locale": {
+        "fr": "Manza\u00ef",
+        "de": "Mobai",
+        "ko": "\uaf2c\uc9c0\uc9c0",
+        "ja": "\u30a6\u30bd\u30cf\u30c1",
+        "zh_CN": "\u7231\u54ed\u6811",
+        "zh_TW": "\u611b\u54ed\u6a39"
+      }
     },
     "Mime Jr.": {
-      "codename": "439"
+      "codename": "439",
+      "locale": {
+        "fr": "Mime Jr.",
+        "de": "Pantimimi",
+        "ko": "\ud749\ub0b4\ub0b4",
+        "ja": "\u30de\u30cd\u30cd",
+        "zh_CN": "\u9b54\u5c3c\u5c3c",
+        "zh_TW": "\u9b54\u5c3c\u5c3c"
+      }
     },
     "Happiny": {
-      "codename": "440"
+      "codename": "440",
+      "locale": {
+        "fr": "Ptiravi",
+        "de": "Wonneira",
+        "ko": "\ud551\ubcf5",
+        "ja": "\u30d4\u30f3\u30d7\u30af",
+        "zh_CN": "\u597d\u8fd0\u86cb",
+        "zh_TW": "\u597d\u904b\u86cb"
+      }
     },
     "Chatot": {
-      "codename": "441"
+      "codename": "441",
+      "locale": {
+        "fr": "Pijako",
+        "de": "Plaudagei",
+        "ko": "\ud398\ub77c\ud398",
+        "ja": "\u30da\u30e9\u30c3\u30d7",
+        "zh_CN": "\u8052\u566a\u9e1f",
+        "zh_TW": "\u8052\u566a\u9ce5"
+      }
     },
     "Spiritomb": {
-      "codename": "442"
+      "codename": "442",
+      "locale": {
+        "fr": "Spiritomb",
+        "de": "Kryppuk",
+        "ko": "\ud654\uac15\ub3cc",
+        "ja": "\u30df\u30ab\u30eb\u30b2",
+        "zh_CN": "\u82b1\u5ca9\u602a",
+        "zh_TW": "\u82b1\u5ca9\u602a"
+      }
     },
     "Gible": {
-      "codename": "443"
+      "codename": "443",
+      "locale": {
+        "fr": "Griknot",
+        "de": "Kaumalat",
+        "ko": "\ub525\uc0c1\uc5b4\ub3d9",
+        "ja": "\u30d5\u30ab\u30de\u30eb",
+        "zh_CN": "\u5706\u9646\u9ca8",
+        "zh_TW": "\u5713\u9678\u9bca"
+      }
     },
     "Gabite": {
-      "codename": "444"
+      "codename": "444",
+      "locale": {
+        "fr": "Carmache",
+        "de": "Knarksel",
+        "ko": "\ud55c\ubc14\uc774\ud2b8",
+        "ja": "\u30ac\u30d0\u30a4\u30c8",
+        "zh_CN": "\u5c16\u7259\u9646\u9ca8",
+        "zh_TW": "\u5c16\u7259\u9678\u9bca"
+      }
     },
     "Garchomp": {
-      "codename": "445"
+      "codename": "445",
+      "locale": {
+        "fr": "Carchacrok",
+        "de": "Knakrack",
+        "ko": "\ud55c\uce74\ub9ac\uc544\uc2a4",
+        "ja": "\u30ac\u30d6\u30ea\u30a2\u30b9",
+        "zh_CN": "\u70c8\u54ac\u9646\u9ca8",
+        "zh_TW": "\u70c8\u54ac\u9678\u9bca"
+      }
     },
     "Munchlax": {
-      "codename": "446"
+      "codename": "446",
+      "locale": {
+        "fr": "Goinfrex",
+        "de": "Mampfaxo",
+        "ko": "\uba39\uace0\uc790",
+        "ja": "\u30b4\u30f3\u30d9",
+        "zh_CN": "\u5c0f\u5361\u6bd4\u517d",
+        "zh_TW": "\u5c0f\u5361\u6bd4\u7378"
+      }
     },
     "Riolu": {
-      "codename": "447"
+      "codename": "447",
+      "locale": {
+        "fr": "Riolu",
+        "de": "Riolu",
+        "ko": "\ub9ac\uc624\ub974",
+        "ja": "\u30ea\u30aa\u30eb",
+        "zh_CN": "\u5229\u6b27\u8def",
+        "zh_TW": "\u5229\u6b50\u8def"
+      }
     },
     "Lucario": {
-      "codename": "448"
+      "codename": "448",
+      "locale": {
+        "fr": "Lucario",
+        "de": "Lucario",
+        "ko": "\ub8e8\uce74\ub9ac\uc624",
+        "ja": "\u30eb\u30ab\u30ea\u30aa",
+        "zh_CN": "\u8def\u5361\u5229\u6b27",
+        "zh_TW": "\u8def\u5361\u5229\u6b50"
+      }
     },
     "Hippopotas": {
-      "codename": "449"
+      "codename": "449",
+      "locale": {
+        "fr": "Hippopotas",
+        "de": "Hippopotas",
+        "ko": "\ud788\ud3ec\ud3ec\ud0c0\uc2a4",
+        "ja": "\u30d2\u30dd\u30dd\u30bf\u30b9",
+        "zh_CN": "\u602a\u6cb3\u9a6c",
+        "zh_TW": "\u602a\u6cb3\u99ac"
+      }
     },
     "Hippowdon": {
-      "codename": "450"
+      "codename": "450",
+      "locale": {
+        "fr": "Hippodocus",
+        "de": "Hippoterus",
+        "ko": "\ud558\ub9c8\ub3c8",
+        "ja": "\u30ab\u30d0\u30eb\u30c9\u30f3",
+        "zh_CN": "\u6cb3\u9a6c\u517d",
+        "zh_TW": "\u6cb3\u99ac\u7378"
+      }
     },
     "Skorupi": {
-      "codename": "451"
+      "codename": "451",
+      "locale": {
+        "fr": "Rapion",
+        "de": "Pionskora",
+        "ko": "\uc2a4\ucf5c\ud53c",
+        "ja": "\u30b9\u30b3\u30eb\u30d4",
+        "zh_CN": "\u7d2b\u5929\u874e",
+        "zh_TW": "\u7d2b\u5929\u880d"
+      }
     },
     "Drapion": {
-      "codename": "452"
+      "codename": "452",
+      "locale": {
+        "fr": "Drascore",
+        "de": "Piondragi",
+        "ko": "\ub4dc\ub798\ud53c\uc628",
+        "ja": "\u30c9\u30e9\u30d4\u30aa\u30f3",
+        "zh_CN": "\u9f99\u738b\u874e",
+        "zh_TW": "\u9f8d\u738b\u880d"
+      }
     },
     "Croagunk": {
-      "codename": "453"
+      "codename": "453",
+      "locale": {
+        "fr": "Cradopaud",
+        "de": "Glibunkel",
+        "ko": "\uc090\ub531\uad6c\ub9ac",
+        "ja": "\u30b0\u30ec\u30c3\u30b0\u30eb",
+        "zh_CN": "\u4e0d\u826f\u86d9",
+        "zh_TW": "\u4e0d\u826f\u86d9"
+      }
     },
     "Toxicroak": {
-      "codename": "454"
+      "codename": "454",
+      "locale": {
+        "fr": "Coatox",
+        "de": "Toxiquak",
+        "ko": "\ub3c5\uac1c\uad74",
+        "ja": "\u30c9\u30af\u30ed\u30c3\u30b0",
+        "zh_CN": "\u6bd2\u9ab7\u86d9",
+        "zh_TW": "\u6bd2\u9ab7\u86d9"
+      }
     },
     "Carnivine": {
-      "codename": "455"
+      "codename": "455",
+      "locale": {
+        "fr": "Vortente",
+        "de": "Venuflibis",
+        "ko": "\ubb34\uc2a4\ud2c8\ub2c8",
+        "ja": "\u30de\u30b9\u30ad\u30c3\u30d1",
+        "zh_CN": "\u5c16\u7259\u7b3c",
+        "zh_TW": "\u5c16\u7259\u7c60"
+      }
     },
     "Finneon": {
-      "codename": "456"
+      "codename": "456",
+      "locale": {
+        "fr": "\u00c9cayon",
+        "de": "Finneon",
+        "ko": "\ud615\uad11\uc5b4",
+        "ja": "\u30b1\u30a4\u30b3\u30a6\u30aa",
+        "zh_CN": "\u8424\u5149\u9c7c",
+        "zh_TW": "\u87a2\u5149\u9b5a"
+      }
     },
     "Lumineon": {
-      "codename": "457"
+      "codename": "457",
+      "locale": {
+        "fr": "Lumin\u00e9on",
+        "de": "Lumineon",
+        "ko": "\ub124\uc624\ub77c\uc774\ud2b8",
+        "ja": "\u30cd\u30aa\u30e9\u30f3\u30c8",
+        "zh_CN": "\u9713\u8679\u9c7c",
+        "zh_TW": "\u9713\u8679\u9b5a"
+      }
     },
     "Mantyke": {
-      "codename": "458"
+      "codename": "458",
+      "locale": {
+        "fr": "Babimanta",
+        "de": "Mantirps",
+        "ko": "\ud0c0\ub9cc\ud0c0",
+        "ja": "\u30bf\u30de\u30f3\u30bf",
+        "zh_CN": "\u5c0f\u7403\u98de\u9c7c",
+        "zh_TW": "\u5c0f\u7403\u98db\u9b5a"
+      }
     },
     "Snover": {
-      "codename": "459"
+      "codename": "459",
+      "locale": {
+        "fr": "Blizzi",
+        "de": "Shnebedeck",
+        "ko": "\ub208\uc4f0\uac1c",
+        "ja": "\u30e6\u30ad\u30ab\u30d6\u30ea",
+        "zh_CN": "\u96ea\u7b20\u602a",
+        "zh_TW": "\u96ea\u7b20\u602a"
+      }
     },
     "Abomasnow": {
-      "codename": "460"
+      "codename": "460",
+      "locale": {
+        "fr": "Blizzaroi",
+        "de": "Rexblisar",
+        "ko": "\ub208\uc124\uc655",
+        "ja": "\u30e6\u30ad\u30ce\u30aa\u30fc",
+        "zh_CN": "\u66b4\u96ea\u738b",
+        "zh_TW": "\u66b4\u96ea\u738b"
+      }
     },
     "Weavile": {
-      "codename": "461"
+      "codename": "461",
+      "locale": {
+        "fr": "Dimoret",
+        "de": "Snibunna",
+        "ko": "\ud3ec\ud478\ub2c8\ub77c",
+        "ja": "\u30de\u30cb\u30e5\u30fc\u30e9",
+        "zh_CN": "\u739b\u72c3\u62c9",
+        "zh_TW": "\u746a\u72c3\u62c9"
+      }
     },
     "Magnezone": {
-      "codename": "462"
+      "codename": "462",
+      "locale": {
+        "fr": "Magn\u00e9zone",
+        "de": "Magnezone",
+        "ko": "\uc790\ud3ec\ucf54\uc77c",
+        "ja": "\u30b8\u30d0\u30b3\u30a4\u30eb",
+        "zh_CN": "\u81ea\u7206\u78c1\u602a",
+        "zh_TW": "\u81ea\u7206\u78c1\u602a"
+      }
     },
     "Lickilicky": {
-      "codename": "463"
+      "codename": "463",
+      "locale": {
+        "fr": "Coudlangue",
+        "de": "Schlurplek",
+        "ko": "\ub0b4\ub8f8\ubca8\ud2b8",
+        "ja": "\u30d9\u30ed\u30d9\u30eb\u30c8",
+        "zh_CN": "\u5927\u820c\u8214",
+        "zh_TW": "\u5927\u820c\u8214"
+      }
     },
     "Rhyperior": {
-      "codename": "464"
+      "codename": "464",
+      "locale": {
+        "fr": "Rhinastoc",
+        "de": "Rihornior",
+        "ko": "\uac70\ub300\ucf54\ubfcc\ub9ac",
+        "ja": "\u30c9\u30b5\u30a4\u30c9\u30f3",
+        "zh_CN": "\u8d85\u94c1\u66b4\u9f99",
+        "zh_TW": "\u8d85\u9435\u66b4\u9f8d"
+      }
     },
     "Tangrowth": {
-      "codename": "465"
+      "codename": "465",
+      "locale": {
+        "fr": "Bouldeneu",
+        "de": "Tangoloss",
+        "ko": "\ub369\ucfe0\ub9bc\ubcf4",
+        "ja": "\u30e2\u30b8\u30e3\u30f3\u30dc",
+        "zh_CN": "\u5de8\u8513\u85e4",
+        "zh_TW": "\u5de8\u8513\u85e4"
+      }
     },
     "Electivire": {
-      "codename": "466"
+      "codename": "466",
+      "locale": {
+        "fr": "\u00c9lekable",
+        "de": "Elevoltek",
+        "ko": "\uc5d0\ub808\ud0a4\ube14",
+        "ja": "\u30a8\u30ec\u30ad\u30d6\u30eb",
+        "zh_CN": "\u7535\u51fb\u9b54\u517d",
+        "zh_TW": "\u96fb\u64ca\u9b54\u7378"
+      }
     },
     "Magmortar": {
-      "codename": "467"
+      "codename": "467",
+      "locale": {
+        "fr": "Maganon",
+        "de": "Magbrant",
+        "ko": "\ub9c8\uadf8\ub9c8\ubc88",
+        "ja": "\u30d6\u30fc\u30d0\u30fc\u30f3",
+        "zh_CN": "\u9e2d\u5634\u7130\u9f99",
+        "zh_TW": "\u9d28\u5634\u7130\u9f8d"
+      }
     },
     "Togekiss": {
-      "codename": "468"
+      "codename": "468",
+      "locale": {
+        "fr": "Togekiss",
+        "de": "Togekiss",
+        "ko": "\ud1a0\uac8c\ud0a4\uc2a4",
+        "ja": "\u30c8\u30b2\u30ad\u30c3\u30b9",
+        "zh_CN": "\u6ce2\u514b\u57fa\u65af",
+        "zh_TW": "\u6ce2\u514b\u57fa\u65af"
+      }
     },
     "Yanmega": {
-      "codename": "469"
+      "codename": "469",
+      "locale": {
+        "fr": "Yanm\u00e9ga",
+        "de": "Yanmega",
+        "ko": "\uba54\uac00\uc790\ub9ac",
+        "ja": "\u30e1\u30ac\u30e4\u30f3\u30de",
+        "zh_CN": "\u6885\u5361\u9633\u739b",
+        "zh_TW": "\u6885\u5361\u967d\u746a"
+      }
     },
     "Leafeon": {
-      "codename": "470"
+      "codename": "470",
+      "locale": {
+        "fr": "Phyllali",
+        "de": "Folipurba",
+        "ko": "\ub9ac\ud53c\uc544",
+        "ja": "\u30ea\u30fc\u30d5\u30a3\u30a2",
+        "zh_CN": "\u53f6\u7cbe\u7075",
+        "zh_TW": "\u8449\u7cbe\u9748"
+      }
     },
     "Glaceon": {
-      "codename": "471"
+      "codename": "471",
+      "locale": {
+        "fr": "Givrali",
+        "de": "Glaziola",
+        "ko": "\uae00\ub808\uc774\uc2dc\uc544",
+        "ja": "\u30b0\u30ec\u30a4\u30b7\u30a2",
+        "zh_CN": "\u51b0\u7cbe\u7075",
+        "zh_TW": "\u51b0\u7cbe\u9748"
+      }
     },
     "Gliscor": {
-      "codename": "472"
+      "codename": "472",
+      "locale": {
+        "fr": "Scorvol",
+        "de": "Skorgro",
+        "ko": "\uae00\ub77c\uc774\uc628",
+        "ja": "\u30b0\u30e9\u30a4\u30aa\u30f3",
+        "zh_CN": "\u5929\u874e\u738b",
+        "zh_TW": "\u5929\u880d\u738b"
+      }
     },
     "Mamoswine": {
-      "codename": "473"
+      "codename": "473",
+      "locale": {
+        "fr": "Mammochon",
+        "de": "Mamutel",
+        "ko": "\ub9d8\ubaa8\uafb8\ub9ac",
+        "ja": "\u30de\u30f3\u30e0\u30fc",
+        "zh_CN": "\u8c61\u7259\u732a",
+        "zh_TW": "\u8c61\u7259\u8c6c"
+      }
     },
     "Porygon-Z": {
-      "codename": "474"
+      "codename": "474",
+      "locale": {
+        "fr": "Porygon-Z",
+        "de": "Porygon-Z",
+        "ko": "\ud3f4\ub9ac\uace4Z",
+        "ja": "\u30dd\u30ea\u30b4\u30f3\uff3a",
+        "zh_CN": "3D\u9f99Z",
+        "zh_TW": "3D\u9f8dZ"
+      }
     },
     "Gallade": {
-      "codename": "475"
+      "codename": "475",
+      "locale": {
+        "fr": "Gallame",
+        "de": "Galagladi",
+        "ko": "\uc5d8\ub808\uc774\ub4dc",
+        "ja": "\u30a8\u30eb\u30ec\u30a4\u30c9",
+        "zh_CN": "\u827e\u8def\u96f7\u6735",
+        "zh_TW": "\u827e\u8def\u96f7\u6735"
+      }
     },
     "Probopass": {
-      "codename": "476"
+      "codename": "476",
+      "locale": {
+        "fr": "Tarinorme",
+        "de": "Voluminas",
+        "ko": "\ub300\ucf54\ud30c\uc2a4",
+        "ja": "\u30c0\u30a4\u30ce\u30fc\u30ba",
+        "zh_CN": "\u5927\u671d\u5317\u9f3b",
+        "zh_TW": "\u5927\u671d\u5317\u9f3b"
+      }
     },
     "Dusknoir": {
-      "codename": "477"
+      "codename": "477",
+      "locale": {
+        "fr": "Noctunoir",
+        "de": "Zwirrfinst",
+        "ko": "\uc57c\ub290\uc640\ub974\ubabd",
+        "ja": "\u30e8\u30ce\u30ef\u30fc\u30eb",
+        "zh_CN": "\u591c\u9ed1\u9b54\u4eba",
+        "zh_TW": "\u591c\u9ed1\u9b54\u4eba"
+      }
     },
     "Froslass": {
-      "codename": "478"
+      "codename": "478",
+      "locale": {
+        "fr": "Momartik",
+        "de": "Frosdedje",
+        "ko": "\ub208\uc5ec\uc544",
+        "ja": "\u30e6\u30ad\u30e1\u30ce\u30b3",
+        "zh_CN": "\u96ea\u5996\u5973",
+        "zh_TW": "\u96ea\u5996\u5973"
+      }
     },
     "Rotom": {
-      "codename": "479"
+      "codename": "479",
+      "locale": {
+        "fr": "Motisma",
+        "de": "Rotom",
+        "ko": "\ub85c\ud1a0\ubb34",
+        "ja": "\u30ed\u30c8\u30e0",
+        "zh_CN": "\u6d1b\u6258\u59c6",
+        "zh_TW": "\u6d1b\u6258\u59c6"
+      }
     },
     "Uxie": {
-      "codename": "480"
+      "codename": "480",
+      "locale": {
+        "fr": "Cr\u00e9helf",
+        "de": "Selfe",
+        "ko": "\uc720\ud06c\uc2dc",
+        "ja": "\u30e6\u30af\u30b7\u30fc",
+        "zh_CN": "\u7531\u514b\u5e0c",
+        "zh_TW": "\u7531\u514b\u5e0c"
+      }
     },
     "Mesprit": {
-      "codename": "481"
+      "codename": "481",
+      "locale": {
+        "fr": "Cr\u00e9follet",
+        "de": "Vesprit",
+        "ko": "\uc5e0\ub77c\uc774\ud2b8",
+        "ja": "\u30a8\u30e0\u30ea\u30c3\u30c8",
+        "zh_CN": "\u827e\u59c6\u5229\u591a",
+        "zh_TW": "\u827e\u59c6\u5229\u591a"
+      }
     },
     "Azelf": {
-      "codename": "482"
+      "codename": "482",
+      "locale": {
+        "fr": "Cr\u00e9fadet",
+        "de": "Tobutz",
+        "ko": "\uc544\uadf8\ub188",
+        "ja": "\u30a2\u30b0\u30ce\u30e0",
+        "zh_CN": "\u4e9a\u514b\u8bfa\u59c6",
+        "zh_TW": "\u4e9e\u514b\u8afe\u59c6"
+      }
     },
     "Dialga": {
-      "codename": "483"
+      "codename": "483",
+      "locale": {
+        "fr": "Dialga",
+        "de": "Dialga",
+        "ko": "\ub514\uc544\ub8e8\uac00",
+        "ja": "\u30c7\u30a3\u30a2\u30eb\u30ac",
+        "zh_CN": "\u5e1d\u7259\u5362\u5361",
+        "zh_TW": "\u5e1d\u7259\u76e7\u5361"
+      }
     },
     "Palkia": {
-      "codename": "484"
+      "codename": "484",
+      "locale": {
+        "fr": "Palkia",
+        "de": "Palkia",
+        "ko": "\ud384\uae30\uc544",
+        "ja": "\u30d1\u30eb\u30ad\u30a2",
+        "zh_CN": "\u5e15\u8def\u5947\u72bd",
+        "zh_TW": "\u5e15\u8def\u5947\u72bd"
+      }
     },
     "Heatran": {
-      "codename": "485"
+      "codename": "485",
+      "locale": {
+        "fr": "Heatran",
+        "de": "Heatran",
+        "ko": "\ud788\ub4dc\ub7f0",
+        "ja": "\u30d2\u30fc\u30c9\u30e9\u30f3",
+        "zh_CN": "\u5e2d\u591a\u84dd\u6069",
+        "zh_TW": "\u5e2d\u591a\u85cd\u6069"
+      }
     },
     "Regigigas": {
-      "codename": "486"
+      "codename": "486",
+      "locale": {
+        "fr": "Regigigas",
+        "de": "Regigigas",
+        "ko": "\ub808\uc9c0\uae30\uac00\uc2a4",
+        "ja": "\u30ec\u30b8\u30ae\u30ac\u30b9",
+        "zh_CN": "\u96f7\u5409\u5947\u5361\u65af",
+        "zh_TW": "\u96f7\u5409\u5947\u5361\u65af"
+      }
     },
     "Giratina": {
-      "codename": "487"
+      "codename": "487",
+      "locale": {
+        "fr": "Giratina",
+        "de": "Giratina",
+        "ko": "\uae30\ub77c\ud2f0\ub098",
+        "ja": "\u30ae\u30e9\u30c6\u30a3\u30ca",
+        "zh_CN": "\u9a91\u62c9\u5e1d\u7eb3",
+        "zh_TW": "\u9a0e\u62c9\u5e1d\u7d0d"
+      }
     },
     "Cresselia": {
-      "codename": "488"
+      "codename": "488",
+      "locale": {
+        "fr": "Cresselia",
+        "de": "Cresselia",
+        "ko": "\ud06c\ub808\uc138\ub9ac\uc544",
+        "ja": "\u30af\u30ec\u30bb\u30ea\u30a2",
+        "zh_CN": "\u514b\u96f7\u8272\u5229\u4e9a",
+        "zh_TW": "\u514b\u96f7\u8272\u5229\u4e9e"
+      }
     },
     "Phione": {
-      "codename": "489"
+      "codename": "489",
+      "locale": {
+        "fr": "Phione",
+        "de": "Phione",
+        "ko": "\ud53c\uc624\ub124",
+        "ja": "\u30d5\u30a3\u30aa\u30cd",
+        "zh_CN": "\u970f\u6b27\u7eb3",
+        "zh_TW": "\u970f\u6b50\u7d0d"
+      }
     },
     "Manaphy": {
-      "codename": "490"
+      "codename": "490",
+      "locale": {
+        "fr": "Manaphy",
+        "de": "Manaphy",
+        "ko": "\ub9c8\ub098\ud53c",
+        "ja": "\u30de\u30ca\u30d5\u30a3",
+        "zh_CN": "\u739b\u7eb3\u970f",
+        "zh_TW": "\u746a\u7d0d\u970f"
+      }
     },
     "Darkrai": {
-      "codename": "491"
+      "codename": "491",
+      "locale": {
+        "fr": "Darkrai",
+        "de": "Darkrai",
+        "ko": "\ub2e4\ud06c\ub77c\uc774",
+        "ja": "\u30c0\u30fc\u30af\u30e9\u30a4",
+        "zh_CN": "\u8fbe\u514b\u83b1\u4f0a",
+        "zh_TW": "\u9054\u514b\u840a\u4f0a"
+      }
     },
     "Shaymin": {
-      "codename": "492"
+      "codename": "492",
+      "locale": {
+        "fr": "Shaymin",
+        "de": "Shaymin",
+        "ko": "\uc250\uc774\ubbf8",
+        "ja": "\u30b7\u30a7\u30a4\u30df",
+        "zh_CN": "\u8c22\u7c73",
+        "zh_TW": "\u8b1d\u7c73"
+      }
     },
     "Arceus": {
-      "codename": "493"
+      "codename": "493",
+      "locale": {
+        "fr": "Arceus",
+        "de": "Arceus",
+        "ko": "\uc544\ub974\uc138\uc6b0\uc2a4",
+        "ja": "\u30a2\u30eb\u30bb\u30a6\u30b9",
+        "zh_CN": "\u963f\u5c14\u5b99\u65af",
+        "zh_TW": "\u963f\u723e\u5b99\u65af"
+      }
     },
     "Victini": {
-      "codename": "494"
+      "codename": "494",
+      "locale": {
+        "fr": "Victini",
+        "de": "Victini",
+        "ko": "\ube44\ud06c\ud2f0\ub2c8",
+        "ja": "\u30d3\u30af\u30c6\u30a3\u30cb",
+        "zh_CN": "\u6bd4\u514b\u63d0\u5c3c",
+        "zh_TW": "\u6bd4\u514b\u63d0\u5c3c"
+      }
     },
     "Snivy": {
-      "codename": "495"
+      "codename": "495",
+      "locale": {
+        "fr": "Vip\u00e9lierre",
+        "de": "Serpifeu",
+        "ko": "\uc8fc\ub9ac\ube44\uc580",
+        "ja": "\u30c4\u30bf\u30fc\u30b8\u30e3",
+        "zh_CN": "\u85e4\u85e4\u86c7",
+        "zh_TW": "\u85e4\u85e4\u86c7"
+      }
     },
     "Servine": {
-      "codename": "496"
+      "codename": "496",
+      "locale": {
+        "fr": "Lianaja",
+        "de": "Efoserp",
+        "ko": "\uc0e4\ube44",
+        "ja": "\u30b8\u30e3\u30ce\u30d3\u30fc",
+        "zh_CN": "\u9752\u85e4\u86c7",
+        "zh_TW": "\u9752\u85e4\u86c7"
+      }
     },
     "Serperior": {
-      "codename": "497"
+      "codename": "497",
+      "locale": {
+        "fr": "Majaspic",
+        "de": "Serpiroyal",
+        "ko": "\uc0e4\ub85c\ub2e4",
+        "ja": "\u30b8\u30e3\u30ed\u30fc\u30c0",
+        "zh_CN": "\u541b\u4e3b\u86c7",
+        "zh_TW": "\u541b\u4e3b\u86c7"
+      }
     },
     "Tepig": {
-      "codename": "498"
+      "codename": "498",
+      "locale": {
+        "fr": "Gruikui",
+        "de": "Floink",
+        "ko": "\ub69c\uafb8\ub9ac",
+        "ja": "\u30dd\u30ab\u30d6",
+        "zh_CN": "\u6696\u6696\u732a",
+        "zh_TW": "\u6696\u6696\u8c6c"
+      }
     },
     "Pignite": {
-      "codename": "499"
+      "codename": "499",
+      "locale": {
+        "fr": "Grotichon",
+        "de": "Ferkokel",
+        "ko": "\ucc28\uc624\uafc0",
+        "ja": "\u30c1\u30e3\u30aa\u30d6\u30fc",
+        "zh_CN": "\u7092\u7092\u732a",
+        "zh_TW": "\u7092\u7092\u8c6c"
+      }
     },
     "Emboar": {
-      "codename": "500"
+      "codename": "500",
+      "locale": {
+        "fr": "Roitiflam",
+        "de": "Flambirex",
+        "ko": "\uc5fc\ubb34\uc655",
+        "ja": "\u30a8\u30f3\u30d6\u30aa\u30fc",
+        "zh_CN": "\u708e\u6b66\u738b",
+        "zh_TW": "\u708e\u6b66\u738b"
+      }
     },
     "Oshawott": {
-      "codename": "501"
+      "codename": "501",
+      "locale": {
+        "fr": "Moustillon",
+        "de": "Ottaro",
+        "ko": "\uc218\ub315\uc774",
+        "ja": "\u30df\u30b8\u30e5\u30de\u30eb",
+        "zh_CN": "\u6c34\u6c34\u736d",
+        "zh_TW": "\u6c34\u6c34\u737a"
+      }
     },
     "Dewott": {
-      "codename": "502"
+      "codename": "502",
+      "locale": {
+        "fr": "Mateloutre",
+        "de": "Zwottronin",
+        "ko": "\uc30d\uac80\uc790\ube44",
+        "ja": "\u30d5\u30bf\u30c1\u30de\u30eb",
+        "zh_CN": "\u53cc\u5203\u4e38",
+        "zh_TW": "\u96d9\u5203\u4e38"
+      }
     },
     "Samurott": {
-      "codename": "503"
+      "codename": "503",
+      "locale": {
+        "fr": "Clamiral",
+        "de": "Admurai",
+        "ko": "\ub300\uac80\uadc0",
+        "ja": "\u30c0\u30a4\u30b1\u30f3\u30ad",
+        "zh_CN": "\u5927\u5251\u9b3c",
+        "zh_TW": "\u5927\u528d\u9b3c"
+      }
     },
     "Patrat": {
-      "codename": "504"
+      "codename": "504",
+      "locale": {
+        "fr": "Ratentif",
+        "de": "Nagelotz",
+        "ko": "\ubcf4\ub974\uc950",
+        "ja": "\u30df\u30cd\u30ba\u30df",
+        "zh_CN": "\u63a2\u63a2\u9f20",
+        "zh_TW": "\u63a2\u63a2\u9f20"
+      }
     },
     "Watchog": {
-      "codename": "505"
+      "codename": "505",
+      "locale": {
+        "fr": "Miradar",
+        "de": "Kukmarda",
+        "ko": "\ubcf4\ub974\uadf8",
+        "ja": "\u30df\u30eb\u30db\u30c3\u30b0",
+        "zh_CN": "\u6b65\u54e8\u9f20",
+        "zh_TW": "\u6b65\u54e8\u9f20"
+      }
     },
     "Lillipup": {
-      "codename": "506"
+      "codename": "506",
+      "locale": {
+        "fr": "Ponchiot",
+        "de": "Yorkleff",
+        "ko": "\uc694\ud14c\ub9ac",
+        "ja": "\u30e8\u30fc\u30c6\u30ea\u30fc",
+        "zh_CN": "\u5c0f\u7ea6\u514b",
+        "zh_TW": "\u5c0f\u7d04\u514b"
+      }
     },
     "Herdier": {
-      "codename": "507"
+      "codename": "507",
+      "locale": {
+        "fr": "Ponchien",
+        "de": "Terribark",
+        "ko": "\ud558\ub370\ub9ac\uc5b4",
+        "ja": "\u30cf\u30fc\u30c7\u30ea\u30a2",
+        "zh_CN": "\u54c8\u7ea6\u514b",
+        "zh_TW": "\u54c8\u7d04\u514b"
+      }
     },
     "Stoutland": {
-      "codename": "508"
+      "codename": "508",
+      "locale": {
+        "fr": "Mastouffe",
+        "de": "Bissbark",
+        "ko": "\ubc14\ub79c\ub4dc",
+        "ja": "\u30e0\u30fc\u30e9\u30f3\u30c9",
+        "zh_CN": "\u957f\u6bdb\u72d7",
+        "zh_TW": "\u9577\u6bdb\u72d7"
+      }
     },
     "Purrloin": {
-      "codename": "509"
+      "codename": "509",
+      "locale": {
+        "fr": "Chacripan",
+        "de": "Felilou",
+        "ko": "\uc314\ube44\ub0e5",
+        "ja": "\u30c1\u30e7\u30ed\u30cd\u30b3",
+        "zh_CN": "\u6252\u624b\u732b",
+        "zh_TW": "\u6252\u624b\u8c93"
+      }
     },
     "Liepard": {
-      "codename": "510"
+      "codename": "510",
+      "locale": {
+        "fr": "L\u00e9opardus",
+        "de": "Kleoparda",
+        "ko": "\ub808\ud30c\ub974\ub2e4\uc2a4",
+        "ja": "\u30ec\u30d1\u30eb\u30c0\u30b9",
+        "zh_CN": "\u9177\u8c79",
+        "zh_TW": "\u9177\u8c79"
+      }
     },
     "Pansage": {
-      "codename": "511"
+      "codename": "511",
+      "locale": {
+        "fr": "Feuillajou",
+        "de": "Vegimak",
+        "ko": "\uc57c\ub098\ud504",
+        "ja": "\u30e4\u30ca\u30c3\u30d7",
+        "zh_CN": "\u82b1\u6930\u7334",
+        "zh_TW": "\u82b1\u6930\u7334"
+      }
     },
     "Simisage": {
-      "codename": "512"
+      "codename": "512",
+      "locale": {
+        "fr": "Feuiloutan",
+        "de": "Vegichita",
+        "ko": "\uc57c\ub098\ud0a4",
+        "ja": "\u30e4\u30ca\u30c3\u30ad\u30fc",
+        "zh_CN": "\u82b1\u6930\u733f",
+        "zh_TW": "\u82b1\u6930\u733f"
+      }
     },
     "Pansear": {
-      "codename": "513"
+      "codename": "513",
+      "locale": {
+        "fr": "Flamajou",
+        "de": "Grillmak",
+        "ko": "\ubc14\uc624\ud504",
+        "ja": "\u30d0\u30aa\u30c3\u30d7",
+        "zh_CN": "\u7206\u9999\u7334",
+        "zh_TW": "\u7206\u9999\u7334"
+      }
     },
     "Simisear": {
-      "codename": "514"
+      "codename": "514",
+      "locale": {
+        "fr": "Flamoutan",
+        "de": "Grillchita",
+        "ko": "\ubc14\uc624\ud0a4",
+        "ja": "\u30d0\u30aa\u30c3\u30ad\u30fc",
+        "zh_CN": "\u7206\u9999\u733f",
+        "zh_TW": "\u7206\u9999\u733f"
+      }
     },
     "Panpour": {
-      "codename": "515"
+      "codename": "515",
+      "locale": {
+        "fr": "Flotajou",
+        "de": "Sodamak",
+        "ko": "\uc557\ucc28\ud504",
+        "ja": "\u30d2\u30e4\u30c3\u30d7",
+        "zh_CN": "\u51b7\u6c34\u7334",
+        "zh_TW": "\u51b7\u6c34\u7334"
+      }
     },
     "Simipour": {
-      "codename": "516"
+      "codename": "516",
+      "locale": {
+        "fr": "Flotoutan",
+        "de": "Sodachita",
+        "ko": "\uc557\ucc28\ud0a4",
+        "ja": "\u30d2\u30e4\u30c3\u30ad\u30fc",
+        "zh_CN": "\u51b7\u6c34\u733f",
+        "zh_TW": "\u51b7\u6c34\u733f"
+      }
     },
     "Munna": {
-      "codename": "517"
+      "codename": "517",
+      "locale": {
+        "fr": "Munna",
+        "de": "Somniam",
+        "ko": "\ubabd\ub098",
+        "ja": "\u30e0\u30f3\u30ca",
+        "zh_CN": "\u98df\u68a6\u68a6",
+        "zh_TW": "\u98df\u5922\u5922"
+      }
     },
     "Musharna": {
-      "codename": "518"
+      "codename": "518",
+      "locale": {
+        "fr": "Mushana",
+        "de": "Somnivora",
+        "ko": "\ubabd\uc58c\ub098",
+        "ja": "\u30e0\u30b7\u30e3\u30fc\u30ca",
+        "zh_CN": "\u68a6\u68a6\u8680",
+        "zh_TW": "\u5922\u5922\u8755"
+      }
     },
     "Pidove": {
-      "codename": "519"
+      "codename": "519",
+      "locale": {
+        "fr": "Poichigeon",
+        "de": "Dusselgurr",
+        "ko": "\ucf69\ub458\uae30",
+        "ja": "\u30de\u30e1\u30d1\u30c8",
+        "zh_CN": "\u8c46\u8c46\u9e3d",
+        "zh_TW": "\u8c46\u8c46\u9d3f"
+      }
     },
     "Tranquill": {
-      "codename": "520"
+      "codename": "520",
+      "locale": {
+        "fr": "Colombeau",
+        "de": "Navitaub",
+        "ko": "\uc720\ud1a0\ube0c",
+        "ja": "\u30cf\u30c8\u30fc\u30dc\u30fc",
+        "zh_CN": "\u6ce2\u6ce2\u9e3d",
+        "zh_TW": "\u6ce2\u6ce2\u9d3f"
+      }
     },
     "Unfezant": {
-      "codename": "521"
+      "codename": "521",
+      "locale": {
+        "fr": "D\u00e9flaisan",
+        "de": "Fasasnob",
+        "ko": "\ucf04\ud638\ub85c\uc6b0",
+        "ja": "\u30b1\u30f3\u30db\u30ed\u30a6",
+        "zh_CN": "\u8f70\u9686\u96c9\u9e21",
+        "zh_TW": "\u8f5f\u9686\u96c9\u96de"
+      }
     },
     "Blitzle": {
-      "codename": "522"
+      "codename": "522",
+      "locale": {
+        "fr": "Z\u00e9bribon",
+        "de": "Elezeba",
+        "ko": "\uc904\ubba4\ub9c8",
+        "ja": "\u30b7\u30de\u30de",
+        "zh_CN": "\u6591\u6591\u9a6c",
+        "zh_TW": "\u6591\u6591\u99ac"
+      }
     },
     "Zebstrika": {
-      "codename": "523"
+      "codename": "523",
+      "locale": {
+        "fr": "Z\u00e9blitz",
+        "de": "Zebritz",
+        "ko": "\uc81c\ube0c\ub77c\uc774\uce74",
+        "ja": "\u30bc\u30d6\u30e9\u30a4\u30ab",
+        "zh_CN": "\u96f7\u7535\u6591\u9a6c",
+        "zh_TW": "\u96f7\u96fb\u6591\u99ac"
+      }
     },
     "Roggenrola": {
-      "codename": "524"
+      "codename": "524",
+      "locale": {
+        "fr": "Nodulithe",
+        "de": "Kiesling",
+        "ko": "\ub2e8\uad74",
+        "ja": "\u30c0\u30f3\u30b4\u30ed",
+        "zh_CN": "\u77f3\u4e38\u5b50",
+        "zh_TW": "\u77f3\u4e38\u5b50"
+      }
     },
     "Boldore": {
-      "codename": "525"
+      "codename": "525",
+      "locale": {
+        "fr": "G\u00e9olithe",
+        "de": "Sedimantur",
+        "ko": "\uc554\ud2b8\ub974",
+        "ja": "\u30ac\u30f3\u30c8\u30eb",
+        "zh_CN": "\u5730\u5e54\u5ca9",
+        "zh_TW": "\u5730\u5e54\u5ca9"
+      }
     },
     "Gigalith": {
-      "codename": "526"
+      "codename": "526",
+      "locale": {
+        "fr": "Gigalithe",
+        "de": "Brockoloss",
+        "ko": "\uae30\uac00\uc774\uc5b4\uc2a4",
+        "ja": "\u30ae\u30ac\u30a4\u30a2\u30b9",
+        "zh_CN": "\u5e9e\u5ca9\u602a",
+        "zh_TW": "\u9f90\u5ca9\u602a"
+      }
     },
     "Woobat": {
-      "codename": "527"
+      "codename": "527",
+      "locale": {
+        "fr": "Chovsourir",
+        "de": "Fleknoil",
+        "ko": "\ub610\ub974\ubc15\uc950",
+        "ja": "\u30b3\u30ed\u30e2\u30ea",
+        "zh_CN": "\u6eda\u6eda\u8759\u8760",
+        "zh_TW": "\u6efe\u6efe\u8759\u8760"
+      }
     },
     "Swoobat": {
-      "codename": "528"
+      "codename": "528",
+      "locale": {
+        "fr": "Rhinolove",
+        "de": "Fletiamo",
+        "ko": "\ub9d8\ubc15\uc950",
+        "ja": "\u30b3\u30b3\u30ed\u30e2\u30ea",
+        "zh_CN": "\u5fc3\u8759\u8760",
+        "zh_TW": "\u5fc3\u8759\u8760"
+      }
     },
     "Drilbur": {
-      "codename": "529"
+      "codename": "529",
+      "locale": {
+        "fr": "Rototaupe",
+        "de": "Rotomurf",
+        "ko": "\ub450\ub354\ub958",
+        "ja": "\u30e2\u30b0\u30ea\u30e5\u30fc",
+        "zh_CN": "\u87ba\u9489\u5730\u9f20",
+        "zh_TW": "\u87ba\u91d8\u5730\u9f20"
+      }
     },
     "Excadrill": {
-      "codename": "530"
+      "codename": "530",
+      "locale": {
+        "fr": "Minotaupe",
+        "de": "Stalobor",
+        "ko": "\ubab0\ub4dc\ub958",
+        "ja": "\u30c9\u30ea\u30e5\u30a6\u30ba",
+        "zh_CN": "\u9f99\u5934\u5730\u9f20",
+        "zh_TW": "\u9f8d\u982d\u5730\u9f20"
+      }
     },
     "Audino": {
-      "codename": "531"
+      "codename": "531",
+      "locale": {
+        "fr": "Nanm\u00e9ou\u00efe",
+        "de": "Ohrdoch",
+        "ko": "\ub2e4\ubd80\ub2c8",
+        "ja": "\u30bf\u30d6\u30f3\u30cd",
+        "zh_CN": "\u5dee\u4e0d\u591a\u5a03\u5a03",
+        "zh_TW": "\u5dee\u4e0d\u591a\u5a03\u5a03"
+      }
     },
     "Timburr": {
-      "codename": "532"
+      "codename": "532",
+      "locale": {
+        "fr": "Charpenti",
+        "de": "Praktibalk",
+        "ko": "\uc73c\ub78f\ucc28",
+        "ja": "\u30c9\u30c3\u30b3\u30e9\u30fc",
+        "zh_CN": "\u642c\u8fd0\u5c0f\u5320",
+        "zh_TW": "\u642c\u904b\u5c0f\u5320"
+      }
     },
     "Gurdurr": {
-      "codename": "533"
+      "codename": "533",
+      "locale": {
+        "fr": "Ouvrifier",
+        "de": "Strepoli",
+        "ko": "\ud1a0\uc1e0\uace8",
+        "ja": "\u30c9\u30c6\u30c3\u30b3\u30c4",
+        "zh_CN": "\u94c1\u9aa8\u571f\u4eba",
+        "zh_TW": "\u9435\u9aa8\u571f\u4eba"
+      }
     },
     "Conkeldurr": {
-      "codename": "534"
+      "codename": "534",
+      "locale": {
+        "fr": "B\u00e9tochef",
+        "de": "Meistagrif",
+        "ko": "\ub178\ubcf4\uccad",
+        "ja": "\u30ed\u30fc\u30d6\u30b7\u30f3",
+        "zh_CN": "\u4fee\u7f2e\u8001\u5934",
+        "zh_TW": "\u4fee\u7e55\u8001\u982d"
+      }
     },
     "Tympole": {
-      "codename": "535"
+      "codename": "535",
+      "locale": {
+        "fr": "Tritonde",
+        "de": "Schallquap",
+        "ko": "\ub3d9\ucc59\uc774",
+        "ja": "\u30aa\u30bf\u30de\u30ed",
+        "zh_CN": "\u5706\u874c\u86aa",
+        "zh_TW": "\u5713\u874c\u86aa"
+      }
     },
     "Palpitoad": {
-      "codename": "536"
+      "codename": "536",
+      "locale": {
+        "fr": "Batracn\u00e9",
+        "de": "Mebrana",
+        "ko": "\ub450\uae4c\ube44",
+        "ja": "\u30ac\u30de\u30ac\u30eb",
+        "zh_CN": "\u84dd\u87fe\u870d",
+        "zh_TW": "\u85cd\u87fe\u870d"
+      }
     },
     "Seismitoad": {
-      "codename": "537"
+      "codename": "537",
+      "locale": {
+        "fr": "Crapustule",
+        "de": "Branawarz",
+        "ko": "\ub450\ube45\uad74",
+        "ja": "\u30ac\u30de\u30b2\u30ed\u30b2",
+        "zh_CN": "\u87fe\u870d\u738b",
+        "zh_TW": "\u87fe\u870d\u738b"
+      }
     },
     "Throh": {
-      "codename": "538"
+      "codename": "538",
+      "locale": {
+        "fr": "Judokrak",
+        "de": "Jiutesto",
+        "ko": "\ub358\uc9c0\ubbf8",
+        "ja": "\u30ca\u30b2\u30ad",
+        "zh_CN": "\u6295\u5c04\u9b3c",
+        "zh_TW": "\u6295\u5c04\u9b3c"
+      }
     },
     "Sawk": {
-      "codename": "539"
+      "codename": "539",
+      "locale": {
+        "fr": "Karacl\u00e9e",
+        "de": "Karadonis",
+        "ko": "\ud0c0\uaca9\uadc0",
+        "ja": "\u30c0\u30b2\u30ad",
+        "zh_CN": "\u6253\u51fb\u9b3c",
+        "zh_TW": "\u6253\u64ca\u9b3c"
+      }
     },
     "Sewaddle": {
-      "codename": "540"
+      "codename": "540",
+      "locale": {
+        "fr": "Larveyette",
+        "de": "Strawickl",
+        "ko": "\ub450\ub974\ubcf4",
+        "ja": "\u30af\u30eb\u30df\u30eb",
+        "zh_CN": "\u866b\u5b9d\u5305",
+        "zh_TW": "\u87f2\u5bf6\u5305"
+      }
     },
     "Swadloon": {
-      "codename": "541"
+      "codename": "541",
+      "locale": {
+        "fr": "Couverdure",
+        "de": "Folikon",
+        "ko": "\ub450\ub974\ucfe4",
+        "ja": "\u30af\u30eb\u30de\u30e6",
+        "zh_CN": "\u5b9d\u5305\u8327",
+        "zh_TW": "\u5bf6\u5305\u7e6d"
+      }
     },
     "Leavanny": {
-      "codename": "542"
+      "codename": "542",
+      "locale": {
+        "fr": "Manternel",
+        "de": "Matrifol",
+        "ko": "\ubaa8\uc544\uba38",
+        "ja": "\u30cf\u30cf\u30b3\u30e2\u30ea",
+        "zh_CN": "\u4fdd\u6bcd\u866b",
+        "zh_TW": "\u4fdd\u6bcd\u87f2"
+      }
     },
     "Venipede": {
-      "codename": "543"
+      "codename": "543",
+      "locale": {
+        "fr": "Venipatte",
+        "de": "Toxiped",
+        "ko": "\ub9c8\ub514\ub124",
+        "ja": "\u30d5\u30b7\u30c7",
+        "zh_CN": "\u767e\u8db3\u8708\u86a3",
+        "zh_TW": "\u767e\u8db3\u8708\u86a3"
+      }
     },
     "Whirlipede": {
-      "codename": "544"
+      "codename": "544",
+      "locale": {
+        "fr": "Scobolide",
+        "de": "Rollum",
+        "ko": "\ud720\uad6c",
+        "ja": "\u30db\u30a4\u30fc\u30ac",
+        "zh_CN": "\u8f66\u8f6e\u7403",
+        "zh_TW": "\u8eca\u8f2a\u6bec"
+      }
     },
     "Scolipede": {
-      "codename": "545"
+      "codename": "545",
+      "locale": {
+        "fr": "Brutapode",
+        "de": "Cerapendra",
+        "ko": "\ud39c\ub4dc\ub77c",
+        "ja": "\u30da\u30f3\u30c9\u30e9\u30fc",
+        "zh_CN": "\u8708\u86a3\u738b",
+        "zh_TW": "\u8708\u86a3\u738b"
+      }
     },
     "Cottonee": {
-      "codename": "546"
+      "codename": "546",
+      "locale": {
+        "fr": "Doudouvet",
+        "de": "Waumboll",
+        "ko": "\uc18c\ubbf8\uc548",
+        "ja": "\u30e2\u30f3\u30e1\u30f3",
+        "zh_CN": "\u6728\u68c9\u7403",
+        "zh_TW": "\u6728\u68c9\u7403"
+      }
     },
     "Whimsicott": {
-      "codename": "547"
+      "codename": "547",
+      "locale": {
+        "fr": "Farfaduvet",
+        "de": "Elfun",
+        "ko": "\uc5d8\ud48d",
+        "ja": "\u30a8\u30eb\u30d5\u30fc\u30f3",
+        "zh_CN": "\u98ce\u5996\u7cbe",
+        "zh_TW": "\u98a8\u5996\u7cbe"
+      }
     },
     "Petilil": {
-      "codename": "548"
+      "codename": "548",
+      "locale": {
+        "fr": "Chlorobule",
+        "de": "Lilminip",
+        "ko": "\uce58\ub9b4\ub9ac",
+        "ja": "\u30c1\u30e5\u30ea\u30cd",
+        "zh_CN": "\u767e\u5408\u6839\u5a03\u5a03",
+        "zh_TW": "\u767e\u5408\u6839\u5a03\u5a03"
+      }
     },
     "Lilligant": {
-      "codename": "549"
+      "codename": "549",
+      "locale": {
+        "fr": "Fragilady",
+        "de": "Dressella",
+        "ko": "\ub4dc\ub808\ub514\uc5b4",
+        "ja": "\u30c9\u30ec\u30c7\u30a3\u30a2",
+        "zh_CN": "\u88d9\u513f\u5c0f\u59d0",
+        "zh_TW": "\u88d9\u5152\u5c0f\u59d0"
+      }
     },
     "Basculin": {
-      "codename": "550"
+      "codename": "550",
+      "locale": {
+        "fr": "Bargantua",
+        "de": "Barschuft",
+        "ko": "\ubc30\uc4f0\ub098\uc774",
+        "ja": "\u30d0\u30b9\u30e9\u30aa",
+        "zh_CN": "\u52c7\u58eb\u9c88\u9c7c",
+        "zh_TW": "\u52c7\u58eb\u9c78\u9b5a"
+      }
     },
     "Sandile": {
-      "codename": "551"
+      "codename": "551",
+      "locale": {
+        "fr": "Masca\u00efman",
+        "de": "Ganovil",
+        "ko": "\uae5c\ub208\ud06c",
+        "ja": "\u30e1\u30b0\u30ed\u30b3",
+        "zh_CN": "\u9ed1\u773c\u9cc4",
+        "zh_TW": "\u9ed1\u773c\u9c77"
+      }
     },
     "Krokorok": {
-      "codename": "552"
+      "codename": "552",
+      "locale": {
+        "fr": "Escroco",
+        "de": "Rokkaiman",
+        "ko": "\uc545\ube44\ub974",
+        "ja": "\u30ef\u30eb\u30d3\u30eb",
+        "zh_CN": "\u6df7\u6df7\u9cc4",
+        "zh_TW": "\u6df7\u6df7\u9c77"
+      }
     },
     "Krookodile": {
-      "codename": "553"
+      "codename": "553",
+      "locale": {
+        "fr": "Crocorible",
+        "de": "Rabigator",
+        "ko": "\uc545\ube44\uc544\ub974",
+        "ja": "\u30ef\u30eb\u30d3\u30a2\u30eb",
+        "zh_CN": "\u6d41\u6c13\u9cc4",
+        "zh_TW": "\u6d41\u6c13\u9c77"
+      }
     },
     "Darumaka": {
-      "codename": "554"
+      "codename": "554",
+      "locale": {
+        "fr": "Darumarond",
+        "de": "Flampion",
+        "ko": "\ub2ec\ub9c9\ud654",
+        "ja": "\u30c0\u30eb\u30de\u30c3\u30ab",
+        "zh_CN": "\u706b\u7ea2\u4e0d\u5012\u7fc1",
+        "zh_TW": "\u706b\u7d05\u4e0d\u5012\u7fc1"
+      }
     },
     "Darmanitan": {
-      "codename": "555"
+      "codename": "555",
+      "locale": {
+        "fr": "Darumacho",
+        "de": "Flampivian",
+        "ko": "\ubd88\ube44\ub2ec\ub9c8",
+        "ja": "\u30d2\u30d2\u30c0\u30eb\u30de",
+        "zh_CN": "\u8fbe\u6469\u72d2\u72d2",
+        "zh_TW": "\u9054\u6469\u72d2\u72d2"
+      }
     },
     "Maractus": {
-      "codename": "556"
+      "codename": "556",
+      "locale": {
+        "fr": "Maracachi",
+        "de": "Maracamba",
+        "ko": "\ub9c8\ub77c\uce74\uce58",
+        "ja": "\u30de\u30e9\u30ab\u30c3\u30c1",
+        "zh_CN": "\u8857\u5934\u6c99\u94c3",
+        "zh_TW": "\u8857\u982d\u6c99\u9234"
+      }
     },
     "Dwebble": {
-      "codename": "557"
+      "codename": "557",
+      "locale": {
+        "fr": "Crabicoque",
+        "de": "Lithomith",
+        "ko": "\ub3cc\uc0b4\uc774",
+        "ja": "\u30a4\u30b7\u30ba\u30de\u30a4",
+        "zh_CN": "\u77f3\u5c45\u87f9",
+        "zh_TW": "\u77f3\u5c45\u87f9"
+      }
     },
     "Crustle": {
-      "codename": "558"
+      "codename": "558",
+      "locale": {
+        "fr": "Crabaraque",
+        "de": "Castellith",
+        "ko": "\uc554\ud330\ub9ac\uc2a4",
+        "ja": "\u30a4\u30ef\u30d1\u30ec\u30b9",
+        "zh_CN": "\u5ca9\u6bbf\u5c45\u87f9",
+        "zh_TW": "\u5ca9\u6bbf\u5c45\u87f9"
+      }
     },
     "Scraggy": {
-      "codename": "559"
+      "codename": "559",
+      "locale": {
+        "fr": "Baggiguane",
+        "de": "Zurrokex",
+        "ko": "\uace4\uc728\ub7ad",
+        "ja": "\u30ba\u30eb\u30c3\u30b0",
+        "zh_CN": "\u6ed1\u5934\u5c0f\u5b50",
+        "zh_TW": "\u6ed1\u982d\u5c0f\u5b50"
+      }
     },
     "Scrafty": {
-      "codename": "560"
+      "codename": "560",
+      "locale": {
+        "fr": "Bagga\u00efd",
+        "de": "Irokex",
+        "ko": "\uace4\uc728\uac70\ub2c8",
+        "ja": "\u30ba\u30eb\u30ba\u30ad\u30f3",
+        "zh_CN": "\u5934\u5dfe\u6df7\u6df7",
+        "zh_TW": "\u982d\u5dfe\u6df7\u6df7"
+      }
     },
     "Sigilyph": {
-      "codename": "561"
+      "codename": "561",
+      "locale": {
+        "fr": "Crypt\u00e9ro",
+        "de": "Symvolara",
+        "ko": "\uc2ec\ubcf4\ub7ec",
+        "ja": "\u30b7\u30f3\u30dc\u30e9\u30fc",
+        "zh_CN": "\u8c61\u5f81\u9e1f",
+        "zh_TW": "\u8c61\u5fb5\u9ce5"
+      }
     },
     "Yamask": {
-      "codename": "562"
+      "codename": "562",
+      "locale": {
+        "fr": "Tutafeh",
+        "de": "Makabaja",
+        "ko": "\ub370\uc2a4\ub9c8\uc2a4",
+        "ja": "\u30c7\u30b9\u30de\u30b9",
+        "zh_CN": "\u54ed\u54ed\u9762\u5177",
+        "zh_TW": "\u54ed\u54ed\u9762\u5177"
+      }
     },
     "Cofagrigus": {
-      "codename": "563"
+      "codename": "563",
+      "locale": {
+        "fr": "Tutankafer",
+        "de": "Echnatoll",
+        "ko": "\ub370\uc2a4\ub2c8\uce78",
+        "ja": "\u30c7\u30b9\u30ab\u30fc\u30f3",
+        "zh_CN": "\u6b7b\u795e\u68fa",
+        "zh_TW": "\u6b7b\u795e\u68fa"
+      }
     },
     "Tirtouga": {
-      "codename": "564"
+      "codename": "564",
+      "locale": {
+        "fr": "Carapagos",
+        "de": "Galapaflos",
+        "ko": "\ud504\ub85c\ud1a0\uac00",
+        "ja": "\u30d7\u30ed\u30c8\u30fc\u30ac",
+        "zh_CN": "\u539f\u76d6\u6d77\u9f9f",
+        "zh_TW": "\u539f\u84cb\u6d77\u9f9c"
+      }
     },
     "Carracosta": {
-      "codename": "565"
+      "codename": "565",
+      "locale": {
+        "fr": "M\u00e9gapagos",
+        "de": "Karippas",
+        "ko": "\ub291\uace8\ub77c",
+        "ja": "\u30a2\u30d0\u30b4\u30fc\u30e9",
+        "zh_CN": "\u808b\u9aa8\u6d77\u9f9f",
+        "zh_TW": "\u808b\u9aa8\u6d77\u9f9c"
+      }
     },
     "Archen": {
-      "codename": "566"
+      "codename": "566",
+      "locale": {
+        "fr": "Ark\u00e9apti",
+        "de": "Flapteryx",
+        "ko": "\uc544\ucf04",
+        "ja": "\u30a2\u30fc\u30b1\u30f3",
+        "zh_CN": "\u59cb\u7956\u5c0f\u9e1f",
+        "zh_TW": "\u59cb\u7956\u5c0f\u9ce5"
+      }
     },
     "Archeops": {
-      "codename": "567"
+      "codename": "567",
+      "locale": {
+        "fr": "A\u00e9ropt\u00e9ryx",
+        "de": "Aeropteryx",
+        "ko": "\uc544\ucf00\uc624\uc2a4",
+        "ja": "\u30a2\u30fc\u30b1\u30aa\u30b9",
+        "zh_CN": "\u59cb\u7956\u5927\u9e1f",
+        "zh_TW": "\u59cb\u7956\u5927\u9ce5"
+      }
     },
     "Trubbish": {
-      "codename": "568"
+      "codename": "568",
+      "locale": {
+        "fr": "Miamiasme",
+        "de": "Unrat\u00fctox",
+        "ko": "\uae68\ubd09\uc774",
+        "ja": "\u30e4\u30d6\u30af\u30ed\u30f3",
+        "zh_CN": "\u7834\u7834\u888b",
+        "zh_TW": "\u7834\u7834\u888b"
+      }
     },
     "Garbodor": {
-      "codename": "569"
+      "codename": "569",
+      "locale": {
+        "fr": "Miasmax",
+        "de": "Deponitox",
+        "ko": "\ub354\uc2a4\ud2b8\ub098",
+        "ja": "\u30c0\u30b9\u30c8\u30c0\u30b9",
+        "zh_CN": "\u7070\u5c18\u5c71",
+        "zh_TW": "\u7070\u5875\u5c71"
+      }
     },
     "Zorua": {
-      "codename": "570"
+      "codename": "570",
+      "locale": {
+        "fr": "Zorua",
+        "de": "Zorua",
+        "ko": "\uc870\ub85c\uc544",
+        "ja": "\u30be\u30ed\u30a2",
+        "zh_CN": "\u7d22\u7f57\u4e9a",
+        "zh_TW": "\u7d22\u7f85\u4e9e"
+      }
     },
     "Zoroark": {
-      "codename": "571"
+      "codename": "571",
+      "locale": {
+        "fr": "Zoroark",
+        "de": "Zoroark",
+        "ko": "\uc870\ub85c\uc544\ud06c",
+        "ja": "\u30be\u30ed\u30a2\u30fc\u30af",
+        "zh_CN": "\u7d22\u7f57\u4e9a\u514b",
+        "zh_TW": "\u7d22\u7f85\u4e9e\u514b"
+      }
     },
     "Minccino": {
-      "codename": "572"
+      "codename": "572",
+      "locale": {
+        "fr": "Chinchidou",
+        "de": "Picochilla",
+        "ko": "\uce58\ub77c\ubbf8",
+        "ja": "\u30c1\u30e9\u30fc\u30df\u30a3",
+        "zh_CN": "\u6ce1\u6cab\u6817\u9f20",
+        "zh_TW": "\u6ce1\u6cab\u6817\u9f20"
+      }
     },
     "Cinccino": {
-      "codename": "573"
+      "codename": "573",
+      "locale": {
+        "fr": "Pashmilla",
+        "de": "Chillabell",
+        "ko": "\uce58\ub77c\uce58\ub178",
+        "ja": "\u30c1\u30e9\u30c1\u30fc\u30ce",
+        "zh_CN": "\u5947\u8bfa\u6817\u9f20",
+        "zh_TW": "\u5947\u8afe\u6817\u9f20"
+      }
     },
     "Gothita": {
-      "codename": "574"
+      "codename": "574",
+      "locale": {
+        "fr": "Scrutella",
+        "de": "Mollimorba",
+        "ko": "\uace0\ub514\ud0f1",
+        "ja": "\u30b4\u30c1\u30e0",
+        "zh_CN": "\u54e5\u5fb7\u5b9d\u5b9d",
+        "zh_TW": "\u54e5\u5fb7\u5bf6\u5bf6"
+      }
     },
     "Gothorita": {
-      "codename": "575"
+      "codename": "575",
+      "locale": {
+        "fr": "Mesm\u00e9rella",
+        "de": "Hypnomorba",
+        "ko": "\uace0\ub514\ubcf4\ubbf8",
+        "ja": "\u30b4\u30c1\u30df\u30eb",
+        "zh_CN": "\u54e5\u5fb7\u5c0f\u7ae5",
+        "zh_TW": "\u54e5\u5fb7\u5c0f\u7ae5"
+      }
     },
     "Gothitelle": {
-      "codename": "576"
+      "codename": "576",
+      "locale": {
+        "fr": "Sid\u00e9rella",
+        "de": "Morbitesse",
+        "ko": "\uace0\ub514\ubaa8\uc544\uc824",
+        "ja": "\u30b4\u30c1\u30eb\u30bc\u30eb",
+        "zh_CN": "\u54e5\u5fb7\u5c0f\u59d0",
+        "zh_TW": "\u54e5\u5fb7\u5c0f\u59d0"
+      }
     },
     "Solosis": {
-      "codename": "577"
+      "codename": "577",
+      "locale": {
+        "fr": "Nucl\u00e9os",
+        "de": "Monozyto",
+        "ko": "\uc720\ub2c8\ub780",
+        "ja": "\u30e6\u30cb\u30e9\u30f3",
+        "zh_CN": "\u5355\u5375\u7ec6\u80de\u7403",
+        "zh_TW": "\u55ae\u5375\u7d30\u80de\u7403"
+      }
     },
     "Duosion": {
-      "codename": "578"
+      "codename": "578",
+      "locale": {
+        "fr": "M\u00e9ios",
+        "de": "Mitodos",
+        "ko": "\ub4c0\ub780",
+        "ja": "\u30c0\u30d6\u30e9\u30f3",
+        "zh_CN": "\u53cc\u5375\u7ec6\u80de\u7403",
+        "zh_TW": "\u96d9\u5375\u7d30\u80de\u7403"
+      }
     },
     "Reuniclus": {
-      "codename": "579"
+      "codename": "579",
+      "locale": {
+        "fr": "Symbios",
+        "de": "Zytomega",
+        "ko": "\ub780\ucfe8\ub8e8\uc2a4",
+        "ja": "\u30e9\u30f3\u30af\u30eb\u30b9",
+        "zh_CN": "\u4eba\u9020\u7ec6\u80de\u5375",
+        "zh_TW": "\u4eba\u9020\u7d30\u80de\u5375"
+      }
     },
     "Ducklett": {
-      "codename": "580"
+      "codename": "580",
+      "locale": {
+        "fr": "Couaneton",
+        "de": "Piccolente",
+        "ko": "\uaf2c\uc9c0\ubcf4\ub9ac",
+        "ja": "\u30b3\u30a2\u30eb\u30d2\u30fc",
+        "zh_CN": "\u9e2d\u5b9d\u5b9d",
+        "zh_TW": "\u9d28\u5bf6\u5bf6"
+      }
     },
     "Swanna": {
-      "codename": "581"
+      "codename": "581",
+      "locale": {
+        "fr": "Lakm\u00e9cygne",
+        "de": "Swaroness",
+        "ko": "\uc2a4\uc644\ub098",
+        "ja": "\u30b9\u30ef\u30f3\u30ca",
+        "zh_CN": "\u9996\u5e2d\u5929\u9e45",
+        "zh_TW": "\u9996\u5e2d\u5929\u9d5d"
+      }
     },
     "Vanillite": {
-      "codename": "582"
+      "codename": "582",
+      "locale": {
+        "fr": "Sorb\u00e9b\u00e9",
+        "de": "Gelatini",
+        "ko": "\ubc14\ub2d0\ud504\ud2f0",
+        "ja": "\u30d0\u30cb\u30d7\u30c3\u30c1",
+        "zh_CN": "\u8ff7\u4f60\u51b0",
+        "zh_TW": "\u8ff7\u4f60\u51b0"
+      }
     },
     "Vanillish": {
-      "codename": "583"
+      "codename": "583",
+      "locale": {
+        "fr": "Sorboul",
+        "de": "Gelatroppo",
+        "ko": "\ubc14\ub2d0\ub9ac\uce58",
+        "ja": "\u30d0\u30cb\u30ea\u30c3\u30c1",
+        "zh_CN": "\u591a\u591a\u51b0",
+        "zh_TW": "\u591a\u591a\u51b0"
+      }
     },
     "Vanilluxe": {
-      "codename": "584"
+      "codename": "584",
+      "locale": {
+        "fr": "Sorbouboul",
+        "de": "Gelatwino",
+        "ko": "\ubc30\ubc14\ub2d0\ub77c",
+        "ja": "\u30d0\u30a4\u30d0\u30cb\u30e9",
+        "zh_CN": "\u53cc\u500d\u591a\u591a\u51b0",
+        "zh_TW": "\u96d9\u500d\u591a\u591a\u51b0"
+      }
     },
     "Deerling": {
-      "codename": "585"
+      "codename": "585",
+      "locale": {
+        "fr": "Vivaldaim",
+        "de": "Sesokitz",
+        "ko": "\uc0ac\ucca0\ub85d",
+        "ja": "\u30b7\u30ad\u30b8\u30ab",
+        "zh_CN": "\u56db\u5b63\u9e7f",
+        "zh_TW": "\u56db\u5b63\u9e7f"
+      }
     },
     "Sawsbuck": {
-      "codename": "586"
+      "codename": "586",
+      "locale": {
+        "fr": "Haydaim",
+        "de": "Kronjuwild",
+        "ko": "\ubc14\ub77c\ucca0\ub85d",
+        "ja": "\u30e1\u30d6\u30ad\u30b8\u30ab",
+        "zh_CN": "\u82bd\u5439\u9e7f",
+        "zh_TW": "\u82bd\u5439\u9e7f"
+      }
     },
     "Emolga": {
-      "codename": "587"
+      "codename": "587",
+      "locale": {
+        "fr": "Emolga",
+        "de": "Emolga",
+        "ko": "\uc5d0\ubabd\uac00",
+        "ja": "\u30a8\u30e2\u30f3\u30ac",
+        "zh_CN": "\u7535\u98de\u9f20",
+        "zh_TW": "\u96fb\u98db\u9f20"
+      }
     },
     "Karrablast": {
-      "codename": "588"
+      "codename": "588",
+      "locale": {
+        "fr": "Carabing",
+        "de": "Laukaps",
+        "ko": "\ub531\uc815\uace4",
+        "ja": "\u30ab\u30d6\u30eb\u30e2",
+        "zh_CN": "\u76d6\u76d6\u866b",
+        "zh_TW": "\u84cb\u84cb\u87f2"
+      }
     },
     "Escavalier": {
-      "codename": "589"
+      "codename": "589",
+      "locale": {
+        "fr": "Lan\u00e7argot",
+        "de": "Cavalanzas",
+        "ko": "\uc288\ubc14\ub974\uace0",
+        "ja": "\u30b7\u30e5\u30d0\u30eb\u30b4",
+        "zh_CN": "\u9a91\u58eb\u8717\u725b",
+        "zh_TW": "\u9a0e\u58eb\u8778\u725b"
+      }
     },
     "Foongus": {
-      "codename": "590"
+      "codename": "590",
+      "locale": {
+        "fr": "Trompignon",
+        "de": "Tarnpignon",
+        "ko": "\uae5c\ub180\ubc84\uc2ac",
+        "ja": "\u30bf\u30de\u30b2\u30bf\u30b1",
+        "zh_CN": "\u5b9d\u8d1d\u7403\u83c7",
+        "zh_TW": "\u5bf6\u8c9d\u7403\u83c7"
+      }
     },
     "Amoonguss": {
-      "codename": "591"
+      "codename": "591",
+      "locale": {
+        "fr": "Gaulet",
+        "de": "Hutsassa",
+        "ko": "\ubf40\ub85d\ub098",
+        "ja": "\u30e2\u30ed\u30d0\u30ec\u30eb",
+        "zh_CN": "\u66b4\u9732\u83c7",
+        "zh_TW": "\u66b4\u9732\u83c7"
+      }
     },
     "Frillish": {
-      "codename": "592"
+      "codename": "592",
+      "locale": {
+        "fr": "Viskuse",
+        "de": "Quabbel",
+        "ko": "\ud0f1\uadf8\ub9b4",
+        "ja": "\u30d7\u30eb\u30ea\u30eb",
+        "zh_CN": "\u8f7b\u98d8\u98d8",
+        "zh_TW": "\u8f15\u98c4\u98c4"
+      }
     },
     "Jellicent": {
-      "codename": "593"
+      "codename": "593",
+      "locale": {
+        "fr": "Moyade",
+        "de": "Apoquallyp",
+        "ko": "\ud0f1\ud0f1\uac94",
+        "ja": "\u30d6\u30eb\u30f3\u30b2\u30eb",
+        "zh_CN": "\u80d6\u561f\u561f",
+        "zh_TW": "\u80d6\u561f\u561f"
+      }
     },
     "Alomomola": {
-      "codename": "594"
+      "codename": "594",
+      "locale": {
+        "fr": "Mamanbo",
+        "de": "Mamolida",
+        "ko": "\ub9d8\ubcf5\uce58",
+        "ja": "\u30de\u30de\u30f3\u30dc\u30a6",
+        "zh_CN": "\u4fdd\u6bcd\u66fc\u6ce2",
+        "zh_TW": "\u4fdd\u6bcd\u66fc\u6ce2"
+      }
     },
     "Joltik": {
-      "codename": "595"
+      "codename": "595",
+      "locale": {
+        "fr": "Statitik",
+        "de": "Wattzapf",
+        "ko": "\ud30c\ucabc\uc625",
+        "ja": "\u30d0\u30c1\u30e5\u30eb",
+        "zh_CN": "\u7535\u7535\u866b",
+        "zh_TW": "\u96fb\u96fb\u87f2"
+      }
     },
     "Galvantula": {
-      "codename": "596"
+      "codename": "596",
+      "locale": {
+        "fr": "Mygavolt",
+        "de": "Voltula",
+        "ko": "\uc804\ud234\ub77c",
+        "ja": "\u30c7\u30f3\u30c1\u30e5\u30e9",
+        "zh_CN": "\u7535\u8718\u86db",
+        "zh_TW": "\u96fb\u8718\u86db"
+      }
     },
     "Ferroseed": {
-      "codename": "597"
+      "codename": "597",
+      "locale": {
+        "fr": "Grindur",
+        "de": "Kastadur",
+        "ko": "\ucca0\uc2dc\ub4dc",
+        "ja": "\u30c6\u30c3\u30b7\u30fc\u30c9",
+        "zh_CN": "\u79cd\u5b50\u94c1\u7403",
+        "zh_TW": "\u7a2e\u5b50\u9435\u7403"
+      }
     },
     "Ferrothorn": {
-      "codename": "598"
+      "codename": "598",
+      "locale": {
+        "fr": "Noacier",
+        "de": "Tentantel",
+        "ko": "\ub108\ud2b8\ub839",
+        "ja": "\u30ca\u30c3\u30c8\u30ec\u30a4",
+        "zh_CN": "\u575a\u679c\u54d1\u94c3",
+        "zh_TW": "\u5805\u679c\u555e\u9234"
+      }
     },
     "Klink": {
-      "codename": "599"
+      "codename": "599",
+      "locale": {
+        "fr": "Tic",
+        "de": "Klikk",
+        "ko": "\uae30\uc5b4\ub974",
+        "ja": "\u30ae\u30a2\u30eb",
+        "zh_CN": "\u9f7f\u8f6e\u513f",
+        "zh_TW": "\u9f52\u8f2a\u5152"
+      }
     },
     "Klang": {
-      "codename": "600"
+      "codename": "600",
+      "locale": {
+        "fr": "Clic",
+        "de": "Kliklak",
+        "ko": "\uae30\uae30\uc5b4\ub974",
+        "ja": "\u30ae\u30ae\u30a2\u30eb",
+        "zh_CN": "\u9f7f\u8f6e\u7ec4",
+        "zh_TW": "\u9f52\u8f2a\u7d44"
+      }
     },
     "Klinklang": {
-      "codename": "601"
+      "codename": "601",
+      "locale": {
+        "fr": "Cliticlic",
+        "de": "Klikdiklak",
+        "ko": "\uae30\uae30\uae30\uc5b4\ub974",
+        "ja": "\u30ae\u30ae\u30ae\u30a2\u30eb",
+        "zh_CN": "\u9f7f\u8f6e\u602a",
+        "zh_TW": "\u9f52\u8f2a\u602a"
+      }
     },
     "Tynamo": {
-      "codename": "602"
+      "codename": "602",
+      "locale": {
+        "fr": "Anchwatt",
+        "de": "Zapplardin",
+        "ko": "\uc800\ub9ac\uc5b4",
+        "ja": "\u30b7\u30d3\u30b7\u30e9\u30b9",
+        "zh_CN": "\u9ebb\u9ebb\u5c0f\u9c7c",
+        "zh_TW": "\u9ebb\u9ebb\u5c0f\u9b5a"
+      }
     },
     "Eelektrik": {
-      "codename": "603"
+      "codename": "603",
+      "locale": {
+        "fr": "Lamp\u00e9roie",
+        "de": "Zapplalek",
+        "ko": "\uc800\ub9ac\ub9b4",
+        "ja": "\u30b7\u30d3\u30d3\u30fc\u30eb",
+        "zh_CN": "\u9ebb\u9ebb\u9cd7",
+        "zh_TW": "\u9ebb\u9ebb\u9c3b"
+      }
     },
     "Eelektross": {
-      "codename": "604"
+      "codename": "604",
+      "locale": {
+        "fr": "Ohmassacre",
+        "de": "Zapplarang",
+        "ko": "\uc800\ub9ac\ub354\ud504",
+        "ja": "\u30b7\u30d3\u30eb\u30c9\u30f3",
+        "zh_CN": "\u9ebb\u9ebb\u9cd7\u9c7c\u738b",
+        "zh_TW": "\u9ebb\u9ebb\u9c3b\u9b5a\u738b"
+      }
     },
     "Elgyem": {
-      "codename": "605"
+      "codename": "605",
+      "locale": {
+        "fr": "Lewsor",
+        "de": "Pygraulon",
+        "ko": "\ub9ac\uadf8\ub808",
+        "ja": "\u30ea\u30b0\u30ec\u30fc",
+        "zh_CN": "\u5c0f\u7070\u602a",
+        "zh_TW": "\u5c0f\u7070\u602a"
+      }
     },
     "Beheeyem": {
-      "codename": "606"
+      "codename": "606",
+      "locale": {
+        "fr": "Neitram",
+        "de": "Megalon",
+        "ko": "\ubcb0\ud06c",
+        "ja": "\u30aa\u30fc\u30d9\u30e0",
+        "zh_CN": "\u5927\u5b87\u602a",
+        "zh_TW": "\u5927\u5b87\u602a"
+      }
     },
     "Litwick": {
-      "codename": "607"
+      "codename": "607",
+      "locale": {
+        "fr": "Fun\u00e9cire",
+        "de": "Lichtel",
+        "ko": "\ubd88\ucf1c\ubbf8",
+        "ja": "\u30d2\u30c8\u30e2\u30b7",
+        "zh_CN": "\u70db\u5149\u7075",
+        "zh_TW": "\u71ed\u5149\u9748"
+      }
     },
     "Lampent": {
-      "codename": "608"
+      "codename": "608",
+      "locale": {
+        "fr": "M\u00e9lancolux",
+        "de": "Laternecto",
+        "ko": "\ub7a8\ud504\ub77c",
+        "ja": "\u30e9\u30f3\u30d7\u30e9\u30fc",
+        "zh_CN": "\u706f\u706b\u5e7d\u7075",
+        "zh_TW": "\u71c8\u706b\u5e7d\u9748"
+      }
     },
     "Chandelure": {
-      "codename": "609"
+      "codename": "609",
+      "locale": {
+        "fr": "Lugulabre",
+        "de": "Skelabra",
+        "ko": "\uc0f9\ub378\ub77c",
+        "ja": "\u30b7\u30e3\u30f3\u30c7\u30e9",
+        "zh_CN": "\u6c34\u6676\u706f\u706b\u7075",
+        "zh_TW": "\u6c34\u6676\u71c8\u706b\u9748"
+      }
     },
     "Axew": {
-      "codename": "610"
+      "codename": "610",
+      "locale": {
+        "fr": "Coupenotte",
+        "de": "Milza",
+        "ko": "\ud130\uac80\ub2c8",
+        "ja": "\u30ad\u30d0\u30b4",
+        "zh_CN": "\u7259\u7259",
+        "zh_TW": "\u7259\u7259"
+      }
     },
     "Fraxure": {
-      "codename": "611"
+      "codename": "611",
+      "locale": {
+        "fr": "Incisache",
+        "de": "Sharfax",
+        "ko": "\uc561\uc2a8\ub3c4",
+        "ja": "\u30aa\u30ce\u30f3\u30c9",
+        "zh_CN": "\u65a7\u7259\u9f99",
+        "zh_TW": "\u65a7\u7259\u9f8d"
+      }
     },
     "Haxorus": {
-      "codename": "612"
+      "codename": "612",
+      "locale": {
+        "fr": "Tranchodon",
+        "de": "Maxax",
+        "ko": "\uc561\uc2a4\ub77c\uc774\uc988",
+        "ja": "\u30aa\u30ce\u30ce\u30af\u30b9",
+        "zh_CN": "\u53cc\u65a7\u6218\u9f99",
+        "zh_TW": "\u96d9\u65a7\u6230\u9f8d"
+      }
     },
     "Cubchoo": {
-      "codename": "613"
+      "codename": "613",
+      "locale": {
+        "fr": "Polarhume",
+        "de": "Petznief",
+        "ko": "\ucf54\uace0\ubbf8",
+        "ja": "\u30af\u30de\u30b7\u30e5\u30f3",
+        "zh_CN": "\u55b7\u568f\u718a",
+        "zh_TW": "\u5674\u568f\u718a"
+      }
     },
     "Beartic": {
-      "codename": "614"
+      "codename": "614",
+      "locale": {
+        "fr": "Polagriffe",
+        "de": "Siberio",
+        "ko": "\ud230\ubca0\uc5b4",
+        "ja": "\u30c4\u30f3\u30d9\u30a2\u30fc",
+        "zh_CN": "\u51bb\u539f\u718a",
+        "zh_TW": "\u51cd\u539f\u718a"
+      }
     },
     "Cryogonal": {
-      "codename": "615"
+      "codename": "615",
+      "locale": {
+        "fr": "Hexagel",
+        "de": "Frigometri",
+        "ko": "\ud504\ub9ac\uc9c0\uc624",
+        "ja": "\u30d5\u30ea\u30fc\u30b8\u30aa",
+        "zh_CN": "\u51e0\u4f55\u96ea\u82b1",
+        "zh_TW": "\u5e7e\u4f55\u96ea\u82b1"
+      }
     },
     "Shelmet": {
-      "codename": "616"
+      "codename": "616",
+      "locale": {
+        "fr": "Escargaume",
+        "de": "Schnuthelm",
+        "ko": "\ucabc\ub9c8\ub9ac",
+        "ja": "\u30c1\u30e7\u30dc\u30de\u30ad",
+        "zh_CN": "\u5c0f\u5634\u8717",
+        "zh_TW": "\u5c0f\u5634\u8778"
+      }
     },
     "Accelgor": {
-      "codename": "617"
+      "codename": "617",
+      "locale": {
+        "fr": "Limaspeed",
+        "de": "Hydragil",
+        "ko": "\uc5b4\uc9c0\ub9ac\ub354",
+        "ja": "\u30a2\u30ae\u30eb\u30c0\u30fc",
+        "zh_CN": "\u654f\u6377\u866b",
+        "zh_TW": "\u654f\u6377\u87f2"
+      }
     },
     "Stunfisk": {
-      "codename": "618"
+      "codename": "618",
+      "locale": {
+        "fr": "Limonde",
+        "de": "Flunschlik",
+        "ko": "\uba54\ub354",
+        "ja": "\u30de\u30c3\u30ae\u30e7",
+        "zh_CN": "\u6ce5\u5df4\u9c7c",
+        "zh_TW": "\u6ce5\u5df4\u9b5a"
+      }
     },
     "Mienfoo": {
-      "codename": "619"
+      "codename": "619",
+      "locale": {
+        "fr": "Kungfouine",
+        "de": "Fu",
+        "ko": "\ube44\uc870\ud478",
+        "ja": "\u30b3\u30b8\u30e7\u30d5\u30fc",
+        "zh_CN": "\u529f\u592b\u9f2c",
+        "zh_TW": "\u529f\u592b\u9f2c"
+      }
     },
     "Mienshao": {
-      "codename": "620"
+      "codename": "620",
+      "locale": {
+        "fr": "Shaofouine",
+        "de": "Shu",
+        "ko": "\ube44\uc870\ub3c4",
+        "ja": "\u30b3\u30b8\u30e7\u30f3\u30c9",
+        "zh_CN": "\u5e08\u7236\u9f2c",
+        "zh_TW": "\u5e2b\u7236\u9f2c"
+      }
     },
     "Druddigon": {
-      "codename": "621"
+      "codename": "621",
+      "locale": {
+        "fr": "Drakkarmin",
+        "de": "Shardrago",
+        "ko": "\ud06c\ub9ac\ub9cc",
+        "ja": "\u30af\u30ea\u30e0\u30ac\u30f3",
+        "zh_CN": "\u8d64\u9762\u9f99",
+        "zh_TW": "\u8d64\u9762\u9f8d"
+      }
     },
     "Golett": {
-      "codename": "622"
+      "codename": "622",
+      "locale": {
+        "fr": "Gringolem",
+        "de": "Golbit",
+        "ko": "\uace8\ube44\ub78c",
+        "ja": "\u30b4\u30d3\u30c3\u30c8",
+        "zh_CN": "\u6ce5\u5076\u5c0f\u4eba",
+        "zh_TW": "\u6ce5\u5076\u5c0f\u4eba"
+      }
     },
     "Golurk": {
-      "codename": "623"
+      "codename": "623",
+      "locale": {
+        "fr": "Golemastoc",
+        "de": "Golgantes",
+        "ko": "\uace8\ub8e8\uadf8",
+        "ja": "\u30b4\u30eb\u30fc\u30b0",
+        "zh_CN": "\u6ce5\u5076\u5de8\u4eba",
+        "zh_TW": "\u6ce5\u5076\u5de8\u4eba"
+      }
     },
     "Pawniard": {
-      "codename": "624"
+      "codename": "624",
+      "locale": {
+        "fr": "Scalpion",
+        "de": "Gladiantri",
+        "ko": "\uc790\ub9dd\uce7c",
+        "ja": "\u30b3\u30de\u30bf\u30ca",
+        "zh_CN": "\u9a79\u5200\u5c0f\u5175",
+        "zh_TW": "\u99d2\u5200\u5c0f\u5175"
+      }
     },
     "Bisharp": {
-      "codename": "625"
+      "codename": "625",
+      "locale": {
+        "fr": "Scalproie",
+        "de": "Caesurio",
+        "ko": "\uc808\uac01\ucc38",
+        "ja": "\u30ad\u30ea\u30ad\u30b6\u30f3",
+        "zh_CN": "\u5288\u65a9\u53f8\u4ee4",
+        "zh_TW": "\u5288\u65ac\u53f8\u4ee4"
+      }
     },
     "Bouffalant": {
-      "codename": "626"
+      "codename": "626",
+      "locale": {
+        "fr": "Frison",
+        "de": "Bisofank",
+        "ko": "\ubc84\ud504\ub860",
+        "ja": "\u30d0\u30c3\u30d5\u30ed\u30f3",
+        "zh_CN": "\u7206\u7206\u5934\u6c34\u725b",
+        "zh_TW": "\u7206\u7206\u982d\u6c34\u725b"
+      }
     },
     "Rufflet": {
-      "codename": "627"
+      "codename": "627",
+      "locale": {
+        "fr": "Furaiglon",
+        "de": "Geronimatz",
+        "ko": "\uc218\ub9ac\ub465\ubcf4",
+        "ja": "\u30ef\u30b7\u30dc\u30f3",
+        "zh_CN": "\u6bdb\u5934\u5c0f\u9e70",
+        "zh_TW": "\u6bdb\u982d\u5c0f\u9df9"
+      }
     },
     "Braviary": {
-      "codename": "628"
+      "codename": "628",
+      "locale": {
+        "fr": "Gueriaigle",
+        "de": "Washakwil",
+        "ko": "\uc6cc\uae00",
+        "ja": "\u30a6\u30a9\u30fc\u30b0\u30eb",
+        "zh_CN": "\u52c7\u58eb\u9e70",
+        "zh_TW": "\u52c7\u58eb\u9df9"
+      }
     },
     "Vullaby": {
-      "codename": "629"
+      "codename": "629",
+      "locale": {
+        "fr": "Vostourno",
+        "de": "Skallyk",
+        "ko": "\ubc8c\ucc28\uc774",
+        "ja": "\u30d0\u30eb\u30c1\u30e3\u30a4",
+        "zh_CN": "\u79c3\u9e70\u5c0f\u5b50",
+        "zh_TW": "\u79bf\u9df9\u5c0f\u5b50"
+      }
     },
     "Mandibuzz": {
-      "codename": "630"
+      "codename": "630",
+      "locale": {
+        "fr": "Vaututrice",
+        "de": "Grypheldis",
+        "ko": "\ubc84\ub79c\uc9c0\ub098",
+        "ja": "\u30d0\u30eb\u30b8\u30fc\u30ca",
+        "zh_CN": "\u79c3\u9e70\u5a1c",
+        "zh_TW": "\u79bf\u9df9\u5a1c"
+      }
     },
     "Heatmor": {
-      "codename": "631"
+      "codename": "631",
+      "locale": {
+        "fr": "Aflamanoir",
+        "de": "Furnifra\u00df",
+        "ko": "\uc564\ud2f0\uace8",
+        "ja": "\u30af\u30a4\u30bf\u30e9\u30f3",
+        "zh_CN": "\u98df\u8681\u7089",
+        "zh_TW": "\u98df\u87fb\u7210"
+      }
     },
     "Durant": {
-      "codename": "632"
+      "codename": "632",
+      "locale": {
+        "fr": "Fermite",
+        "de": "Fermicula",
+        "ko": "\uc544\uc774\uc564\ud2b8",
+        "ja": "\u30a2\u30a4\u30a2\u30f3\u30c8",
+        "zh_CN": "\u94c1\u8681",
+        "zh_TW": "\u9435\u87fb"
+      }
     },
     "Deino": {
-      "codename": "633"
+      "codename": "633",
+      "locale": {
+        "fr": "Solochi",
+        "de": "Kapuno",
+        "ko": "\ubaa8\ub178\ub450",
+        "ja": "\u30e2\u30ce\u30ba",
+        "zh_CN": "\u5355\u9996\u9f99",
+        "zh_TW": "\u55ae\u9996\u9f8d"
+      }
     },
     "Zweilous": {
-      "codename": "634"
+      "codename": "634",
+      "locale": {
+        "fr": "Diamat",
+        "de": "Duodino",
+        "ko": "\ub514\ud5e4\ub4dc",
+        "ja": "\u30b8\u30d8\u30c3\u30c9",
+        "zh_CN": "\u53cc\u5934\u9f99",
+        "zh_TW": "\u96d9\u982d\u9f8d"
+      }
     },
     "Hydreigon": {
-      "codename": "635"
+      "codename": "635",
+      "locale": {
+        "fr": "Trioxhydre",
+        "de": "Trikephalo",
+        "ko": "\uc0bc\uc0bc\ub4dc\ub798",
+        "ja": "\u30b5\u30b6\u30f3\u30c9\u30e9",
+        "zh_CN": "\u4e09\u5934\u9f99",
+        "zh_TW": "\u4e09\u982d\u9f8d"
+      }
     },
     "Larvesta": {
-      "codename": "636"
+      "codename": "636",
+      "locale": {
+        "fr": "Pyronille",
+        "de": "Ignivor",
+        "ko": "\ud65c\ud654\ub974\ubc14",
+        "ja": "\u30e1\u30e9\u30eb\u30d0",
+        "zh_CN": "\u71c3\u70e7\u866b",
+        "zh_TW": "\u71c3\u71d2\u87f2"
+      }
     },
     "Volcarona": {
-      "codename": "637"
+      "codename": "637",
+      "locale": {
+        "fr": "Pyrax",
+        "de": "Ramoth",
+        "ko": "\ubd88\uce74\ubaa8\uc2a4",
+        "ja": "\u30a6\u30eb\u30ac\u30e2\u30b9",
+        "zh_CN": "\u706b\u795e\u866b",
+        "zh_TW": "\u706b\u795e\u87f2"
+      }
     },
     "Cobalion": {
-      "codename": "638"
+      "codename": "638",
+      "locale": {
+        "fr": "Cobaltium",
+        "de": "Kobalium",
+        "ko": "\ucf54\ubc14\ub974\uc628",
+        "ja": "\u30b3\u30d0\u30eb\u30aa\u30f3",
+        "zh_CN": "\u52fe\u5e15\u8def\u7fc1",
+        "zh_TW": "\u52fe\u5e15\u8def\u7fc1"
+      }
     },
     "Terrakion": {
-      "codename": "639"
+      "codename": "639",
+      "locale": {
+        "fr": "Terrakium",
+        "de": "Terrakium",
+        "ko": "\ud14c\ub77c\ud0a4\uc628",
+        "ja": "\u30c6\u30e9\u30ad\u30aa\u30f3",
+        "zh_CN": "\u4ee3\u62c9\u57fa\u7fc1",
+        "zh_TW": "\u4ee3\u62c9\u57fa\u7fc1"
+      }
     },
     "Virizion": {
-      "codename": "640"
+      "codename": "640",
+      "locale": {
+        "fr": "Viridium",
+        "de": "Viridium",
+        "ko": "\ube44\ub9ac\ub514\uc628",
+        "ja": "\u30d3\u30ea\u30b8\u30aa\u30f3",
+        "zh_CN": "\u6bd5\u529b\u5409\u7fc1",
+        "zh_TW": "\u7562\u529b\u5409\u7fc1"
+      }
     },
     "Tornadus": {
-      "codename": "641"
+      "codename": "641",
+      "locale": {
+        "fr": "Bor\u00e9as",
+        "de": "Boreos",
+        "ko": "\ud1a0\ub124\ub85c\uc2a4",
+        "ja": "\u30c8\u30eb\u30cd\u30ed\u30b9",
+        "zh_CN": "\u9f99\u5377\u4e91",
+        "zh_TW": "\u9f8d\u6372\u96f2"
+      }
     },
     "Thundurus": {
-      "codename": "642"
+      "codename": "642",
+      "locale": {
+        "fr": "Fulguris",
+        "de": "Voltolos",
+        "ko": "\ubcfc\ud2b8\ub85c\uc2a4",
+        "ja": "\u30dc\u30eb\u30c8\u30ed\u30b9",
+        "zh_CN": "\u96f7\u7535\u4e91",
+        "zh_TW": "\u96f7\u96fb\u96f2"
+      }
     },
     "Reshiram": {
-      "codename": "643"
+      "codename": "643",
+      "locale": {
+        "fr": "Reshiram",
+        "de": "Reshiram",
+        "ko": "\ub808\uc2dc\ub77c\ubb34",
+        "ja": "\u30ec\u30b7\u30e9\u30e0",
+        "zh_CN": "\u96f7\u5e0c\u62c9\u59c6",
+        "zh_TW": "\u96f7\u5e0c\u62c9\u59c6"
+      }
     },
     "Zekrom": {
-      "codename": "644"
+      "codename": "644",
+      "locale": {
+        "fr": "Zekrom",
+        "de": "Zekrom",
+        "ko": "\uc81c\ud06c\ub85c\ubb34",
+        "ja": "\u30bc\u30af\u30ed\u30e0",
+        "zh_CN": "\u6377\u514b\u7f57\u59c6",
+        "zh_TW": "\u6377\u514b\u7f85\u59c6"
+      }
     },
     "Landorus": {
-      "codename": "645"
+      "codename": "645",
+      "locale": {
+        "fr": "D\u00e9m\u00e9t\u00e9ros",
+        "de": "Demeteros",
+        "ko": "\ub79c\ub4dc\ub85c\uc2a4",
+        "ja": "\u30e9\u30f3\u30c9\u30ed\u30b9",
+        "zh_CN": "\u571f\u5730\u4e91",
+        "zh_TW": "\u571f\u5730\u96f2"
+      }
     },
     "Kyurem": {
-      "codename": "646"
+      "codename": "646",
+      "locale": {
+        "fr": "Kyurem",
+        "de": "Kyurem",
+        "ko": "\ud050\ub808\ubb34",
+        "ja": "\u30ad\u30e5\u30ec\u30e0",
+        "zh_CN": "\u914b\u96f7\u59c6",
+        "zh_TW": "\u914b\u96f7\u59c6"
+      }
     },
     "Keldeo": {
-      "codename": "647"
+      "codename": "647",
+      "locale": {
+        "fr": "Keldeo",
+        "de": "Keldeo",
+        "ko": "\ucf00\ub974\ub514\uc624",
+        "ja": "\u30b1\u30eb\u30c7\u30a3\u30aa",
+        "zh_CN": "\u51ef\u8def\u8fea\u6b27",
+        "zh_TW": "\u51f1\u8def\u8fea\u6b50"
+      }
     },
     "Meloetta": {
-      "codename": "648"
+      "codename": "648",
+      "locale": {
+        "fr": "Meloetta",
+        "de": "Meloetta",
+        "ko": "\uba54\ub85c\uc5e3\ud0c0",
+        "ja": "\u30e1\u30ed\u30a8\u30c3\u30bf",
+        "zh_CN": "\u7f8e\u6d1b\u8036\u5854",
+        "zh_TW": "\u7f8e\u6d1b\u8036\u5854"
+      }
     },
     "Genesect": {
-      "codename": "649"
+      "codename": "649",
+      "locale": {
+        "fr": "Genesect",
+        "de": "Genesect",
+        "ko": "\uac8c\ub178\uc138\ud06c\ud2b8",
+        "ja": "\u30b2\u30ce\u30bb\u30af\u30c8",
+        "zh_CN": "\u76d6\u8bfa\u8d5b\u514b\u7279",
+        "zh_TW": "\u84cb\u8afe\u8cfd\u514b\u7279"
+      }
     },
     "Chespin": {
-      "codename": "650"
+      "codename": "650",
+      "locale": {
+        "fr": "Marisson",
+        "de": "Igamaro",
+        "ko": "\ub3c4\uce58\ub9c8\ub860",
+        "ja": "\u30cf\u30ea\u30de\u30ed\u30f3",
+        "zh_CN": "\u54c8\u529b\u6817",
+        "zh_TW": "\u54c8\u529b\u6817"
+      }
     },
     "Quilladin": {
-      "codename": "651"
+      "codename": "651",
+      "locale": {
+        "fr": "Bogu\u00e9risse",
+        "de": "Igastarnish",
+        "ko": "\ub3c4\uce58\ubcf4\uad6c",
+        "ja": "\u30cf\u30ea\u30dc\u30fc\u30b0",
+        "zh_CN": "\u80d6\u80d6\u54c8\u529b",
+        "zh_TW": "\u80d6\u80d6\u54c8\u529b"
+      }
     },
     "Chesnaught": {
-      "codename": "652"
+      "codename": "652",
+      "locale": {
+        "fr": "Blind\u00e9pique",
+        "de": "Brigaron",
+        "ko": "\ube0c\ub9ac\uac00\ub860",
+        "ja": "\u30d6\u30ea\u30ac\u30ed\u30f3",
+        "zh_CN": "\u5e03\u91cc\u5361\u9686",
+        "zh_TW": "\u5e03\u91cc\u5361\u9686"
+      }
     },
     "Fennekin": {
-      "codename": "653"
+      "codename": "653",
+      "locale": {
+        "fr": "Feunnec",
+        "de": "Fynx",
+        "ko": "\ud478\ud638\uaf2c",
+        "ja": "\u30d5\u30a9\u30c3\u30b3",
+        "zh_CN": "\u706b\u72d0\u72f8",
+        "zh_TW": "\u706b\u72d0\u72f8"
+      }
     },
     "Braixen": {
-      "codename": "654"
+      "codename": "654",
+      "locale": {
+        "fr": "Roussil",
+        "de": "Rutena",
+        "ko": "\ud14c\ub974\ub098",
+        "ja": "\u30c6\u30fc\u30eb\u30ca\u30fc",
+        "zh_CN": "\u957f\u5c3e\u706b\u72d0",
+        "zh_TW": "\u9577\u5c3e\u706b\u72d0"
+      }
     },
     "Delphox": {
-      "codename": "655"
+      "codename": "655",
+      "locale": {
+        "fr": "Goupelin",
+        "de": "Fennexis",
+        "ko": "\ub9c8\ud3ed\uc2dc",
+        "ja": "\u30de\u30d5\u30a9\u30af\u30b7\u30fc",
+        "zh_CN": "\u5996\u706b\u7ea2\u72d0",
+        "zh_TW": "\u5996\u706b\u7d05\u72d0"
+      }
     },
     "Froakie": {
-      "codename": "656"
+      "codename": "656",
+      "locale": {
+        "fr": "Grenousse",
+        "de": "Froxy",
+        "ko": "\uac1c\uad6c\ub9c8\ub974",
+        "ja": "\u30b1\u30ed\u30de\u30c4",
+        "zh_CN": "\u5471\u5471\u6ce1\u86d9",
+        "zh_TW": "\u5471\u5471\u6ce1\u86d9"
+      }
     },
     "Frogadier": {
-      "codename": "657"
+      "codename": "657",
+      "locale": {
+        "fr": "Cro\u00e2poral",
+        "de": "Amphizel",
+        "ko": "\uac1c\uad74\ubc18\uc7a5",
+        "ja": "\u30b2\u30b3\u30ac\u30b7\u30e9",
+        "zh_CN": "\u5471\u5934\u86d9",
+        "zh_TW": "\u5471\u982d\u86d9"
+      }
     },
     "Greninja": {
-      "codename": "658"
+      "codename": "658",
+      "locale": {
+        "fr": "Amphinobi",
+        "de": "Quajutsu",
+        "ko": "\uac1c\uad74\ub2cc\uc790",
+        "ja": "\u30b2\u30c3\u30b3\u30a6\u30ac",
+        "zh_CN": "\u7532\u8d3a\u5fcd\u86d9",
+        "zh_TW": "\u7532\u8cc0\u5fcd\u86d9"
+      }
     },
     "Bunnelby": {
-      "codename": "659"
+      "codename": "659",
+      "locale": {
+        "fr": "Sapereau",
+        "de": "Scoppel",
+        "ko": "\ud30c\ub974\ube57",
+        "ja": "\u30db\u30eb\u30d3\u30fc",
+        "zh_CN": "\u6398\u6398\u5154",
+        "zh_TW": "\u6398\u6398\u5154"
+      }
     },
     "Diggersby": {
-      "codename": "660"
+      "codename": "660",
+      "locale": {
+        "fr": "Excavarenne",
+        "de": "Grebbit",
+        "ko": "\ud30c\ub974\ud1a0",
+        "ja": "\u30db\u30eb\u30fc\u30c9",
+        "zh_CN": "\u6509\u571f\u5154",
+        "zh_TW": "\u6509\u571f\u5154"
+      }
     },
     "Fletchling": {
-      "codename": "661"
+      "codename": "661",
+      "locale": {
+        "fr": "Passerouge",
+        "de": "Dartiri",
+        "ko": "\ud654\uc0b4\uaf2c\ube48",
+        "ja": "\u30e4\u30e4\u30b3\u30de",
+        "zh_CN": "\u5c0f\u7bad\u96c0",
+        "zh_TW": "\u5c0f\u7bad\u96c0"
+      }
     },
     "Fletchinder": {
-      "codename": "662"
+      "codename": "662",
+      "locale": {
+        "fr": "Braisillon",
+        "de": "Dartignis",
+        "ko": "\ubd88\ud654\uc0b4\ube48",
+        "ja": "\u30d2\u30ce\u30e4\u30b3\u30de",
+        "zh_CN": "\u706b\u7bad\u96c0",
+        "zh_TW": "\u706b\u7bad\u96c0"
+      }
     },
     "Talonflame": {
-      "codename": "663"
+      "codename": "663",
+      "locale": {
+        "fr": "Flambusard",
+        "de": "Fiaro",
+        "ko": "\ud30c\uc774\uc5b4\ub85c",
+        "ja": "\u30d5\u30a1\u30a4\u30a2\u30ed\u30fc",
+        "zh_CN": "\u70c8\u7bad\u9e5f",
+        "zh_TW": "\u70c8\u7bad\u9db2"
+      }
     },
     "Scatterbug": {
-      "codename": "664"
+      "codename": "664",
+      "locale": {
+        "fr": "L\u00e9pidonille",
+        "de": "Purmel",
+        "ko": "\ubd84\uc774\ubc8c\ub808",
+        "ja": "\u30b3\u30d5\u30ad\u30e0\u30b7",
+        "zh_CN": "\u7c89\u86f9",
+        "zh_TW": "\u7c89\u86f9"
+      }
     },
     "Spewpa": {
-      "codename": "665"
+      "codename": "665",
+      "locale": {
+        "fr": "P\u00e9r\u00e9grain",
+        "de": "Puponcho",
+        "ko": "\ubd84\ub5a0\ub3c4\ub9ac",
+        "ja": "\u30b3\u30d5\u30fc\u30e9\u30a4",
+        "zh_CN": "\u7c89\u8776\u86f9",
+        "zh_TW": "\u7c89\u8776\u86f9"
+      }
     },
     "Vivillon": {
-      "codename": "666"
+      "codename": "666",
+      "locale": {
+        "fr": "Prismillon",
+        "de": "Vivillon",
+        "ko": "\ube44\ube44\uc6a9",
+        "ja": "\u30d3\u30d3\u30e8\u30f3",
+        "zh_CN": "\u78a7\u7c89\u8776",
+        "zh_TW": "\u78a7\u7c89\u8776"
+      }
     },
     "Litleo": {
-      "codename": "667"
+      "codename": "667",
+      "locale": {
+        "fr": "H\u00e9lionceau",
+        "de": "Leufeo",
+        "ko": "\ub808\uc624\uaf2c",
+        "ja": "\u30b7\u30b7\u30b3",
+        "zh_CN": "\u5c0f\u72ee\u72ee",
+        "zh_TW": "\u5c0f\u7345\u7345"
+      }
     },
     "Pyroar": {
-      "codename": "668"
+      "codename": "668",
+      "locale": {
+        "fr": "N\u00e9m\u00e9lios",
+        "de": "Pyroleo",
+        "ko": "\ud654\uc5fc\ub808\uc624",
+        "ja": "\u30ab\u30a8\u30f3\u30b8\u30b7",
+        "zh_CN": "\u706b\u708e\u72ee",
+        "zh_TW": "\u706b\u708e\u7345"
+      }
     },
     "Flab\u00e9b\u00e9": {
-      "codename": "669"
+      "codename": "669",
+      "locale": {
+        "fr": "Flab\u00e9b\u00e9",
+        "de": "Flab\u00e9b\u00e9",
+        "ko": "\ud50c\ub77c\ubca0\ubca0",
+        "ja": "\u30d5\u30e9\u30d9\u30d9",
+        "zh_CN": "\u82b1\u84d3\u84d3",
+        "zh_TW": "\u82b1\u84d3\u84d3"
+      }
     },
     "Floette": {
-      "codename": "670"
+      "codename": "670",
+      "locale": {
+        "fr": "Floette",
+        "de": "Floette",
+        "ko": "\ud50c\ub77c\uc5e3\ud14c",
+        "ja": "\u30d5\u30e9\u30a8\u30c3\u30c6",
+        "zh_CN": "\u82b1\u53f6\u8482",
+        "zh_TW": "\u82b1\u8449\u8482"
+      }
     },
     "Florges": {
-      "codename": "671"
+      "codename": "671",
+      "locale": {
+        "fr": "Florges",
+        "de": "Florges",
+        "ko": "\ud50c\ub77c\uc81c\uc2a4",
+        "ja": "\u30d5\u30e9\u30fc\u30b8\u30a7\u30b9",
+        "zh_CN": "\u82b1\u6d01\u592b\u4eba",
+        "zh_TW": "\u82b1\u6f54\u592b\u4eba"
+      }
     },
     "Skiddo": {
-      "codename": "672"
+      "codename": "672",
+      "locale": {
+        "fr": "Cabriolaine",
+        "de": "M\u00e4hikel",
+        "ko": "\uba54\uc774\ud074",
+        "ja": "\u30e1\u30a7\u30fc\u30af\u30eb",
+        "zh_CN": "\u54a9\u54a9\u7f8a",
+        "zh_TW": "\u54a9\u54a9\u7f8a"
+      }
     },
     "Gogoat": {
-      "codename": "673"
+      "codename": "673",
+      "locale": {
+        "fr": "Chevroum",
+        "de": "Chevrumm",
+        "ko": "\uace0\uace0\ud2b8",
+        "ja": "\u30b4\u30fc\u30b4\u30fc\u30c8",
+        "zh_CN": "\u5750\u9a91\u5c71\u7f8a",
+        "zh_TW": "\u5750\u9a0e\u5c71\u7f8a"
+      }
     },
     "Pancham": {
-      "codename": "674"
+      "codename": "674",
+      "locale": {
+        "fr": "Pandespi\u00e8gle",
+        "de": "Pam",
+        "ko": "\ud310\uc9f1",
+        "ja": "\u30e4\u30f3\u30c1\u30e3\u30e0",
+        "zh_CN": "\u987d\u76ae\u718a\u732b",
+        "zh_TW": "\u9811\u76ae\u718a\u8c93"
+      }
     },
     "Pangoro": {
-      "codename": "675"
+      "codename": "675",
+      "locale": {
+        "fr": "Pandarbare",
+        "de": "Pandagro",
+        "ko": "\ubd80\ub780\ub2e4",
+        "ja": "\u30b4\u30ed\u30f3\u30c0",
+        "zh_CN": "\u6d41\u6c13\u718a\u732b",
+        "zh_TW": "\u6d41\u6c13\u718a\u8c93"
+      }
     },
     "Furfrou": {
-      "codename": "676"
+      "codename": "676",
+      "locale": {
+        "fr": "Couafarel",
+        "de": "Coiffwaff",
+        "ko": "\ud2b8\ub9ac\ubbf8\uc559",
+        "ja": "\u30c8\u30ea\u30df\u30a2\u30f3",
+        "zh_CN": "\u591a\u4e3d\u7c73\u4e9a",
+        "zh_TW": "\u591a\u9e97\u7c73\u4e9e"
+      }
     },
     "Espurr": {
-      "codename": "677"
+      "codename": "677",
+      "locale": {
+        "fr": "Psystigri",
+        "de": "Psiau",
+        "ko": "\ub0d0\uc2a4\ud37c",
+        "ja": "\u30cb\u30e3\u30b9\u30d1\u30fc",
+        "zh_CN": "\u5999\u55b5",
+        "zh_TW": "\u5999\u55b5"
+      }
     },
     "Meowstic": {
-      "codename": "678"
+      "codename": "678",
+      "locale": {
+        "fr": "Mistigrix",
+        "de": "Psiaugon",
+        "ko": "\ub0d0\uc624\ub2c9\uc2a4",
+        "ja": "\u30cb\u30e3\u30aa\u30cb\u30af\u30b9",
+        "zh_CN": "\u8d85\u80fd\u5999\u55b5",
+        "zh_TW": "\u8d85\u80fd\u5999\u55b5"
+      }
     },
     "Honedge": {
-      "codename": "679"
+      "codename": "679",
+      "locale": {
+        "fr": "Monorpale",
+        "de": "Gramokles",
+        "ko": "\ub2e8\uce7c\ube59",
+        "ja": "\u30d2\u30c8\u30c4\u30ad",
+        "zh_CN": "\u72ec\u5251\u9798",
+        "zh_TW": "\u7368\u528d\u9798"
+      }
     },
     "Doublade": {
-      "codename": "680"
+      "codename": "680",
+      "locale": {
+        "fr": "Dimocl\u00e8s",
+        "de": "Duokles",
+        "ko": "\uc30d\uac80\ud0ac",
+        "ja": "\u30cb\u30c0\u30f3\u30ae\u30eb",
+        "zh_CN": "\u53cc\u5251\u9798",
+        "zh_TW": "\u96d9\u528d\u9798"
+      }
     },
     "Aegislash": {
-      "codename": "681"
+      "codename": "681",
+      "locale": {
+        "fr": "Exagide",
+        "de": "Durengard",
+        "ko": "\ud0ac\uac00\ub974\ub3c4",
+        "ja": "\u30ae\u30eb\u30ac\u30eb\u30c9",
+        "zh_CN": "\u575a\u76fe\u5251\u602a",
+        "zh_TW": "\u5805\u76fe\u528d\u602a"
+      }
     },
     "Spritzee": {
-      "codename": "682"
+      "codename": "682",
+      "locale": {
+        "fr": "Fluvetin",
+        "de": "Parfi",
+        "ko": "\uc288\uc058",
+        "ja": "\u30b7\u30e5\u30b7\u30e5\u30d7",
+        "zh_CN": "\u7c89\u9999\u9999",
+        "zh_TW": "\u7c89\u9999\u9999"
+      }
     },
     "Aromatisse": {
-      "codename": "683"
+      "codename": "683",
+      "locale": {
+        "fr": "Cocotine",
+        "de": "Parfinesse",
+        "ko": "\ud504\ub808\ud504\ud2f0\ub974",
+        "ja": "\u30d5\u30ec\u30d5\u30ef\u30f3",
+        "zh_CN": "\u82b3\u9999\u7cbe",
+        "zh_TW": "\u82b3\u9999\u7cbe"
+      }
     },
     "Swirlix": {
-      "codename": "684"
+      "codename": "684",
+      "locale": {
+        "fr": "Sucroquin",
+        "de": "Flauschling",
+        "ko": "\ub098\ub8f8\ud37c\ud504",
+        "ja": "\u30da\u30ed\u30c3\u30d1\u30d5",
+        "zh_CN": "\u7ef5\u7ef5\u6ce1\u8299",
+        "zh_TW": "\u7dbf\u7dbf\u6ce1\u8299"
+      }
     },
     "Slurpuff": {
-      "codename": "685"
+      "codename": "685",
+      "locale": {
+        "fr": "Cupcanaille",
+        "de": "Sabbaione",
+        "ko": "\ub098\ub8e8\ub9bc",
+        "ja": "\u30da\u30ed\u30ea\u30fc\u30e0",
+        "zh_CN": "\u80d6\u751c\u59ae",
+        "zh_TW": "\u80d6\u751c\u59ae"
+      }
     },
     "Inkay": {
-      "codename": "686"
+      "codename": "686",
+      "locale": {
+        "fr": "Sepiatop",
+        "de": "Iscalar",
+        "ko": "\uc624\ucf00\uc774\uc9d5",
+        "ja": "\u30de\u30fc\u30a4\u30fc\u30ab",
+        "zh_CN": "\u8c6a\u5587\u82b1\u679d",
+        "zh_TW": "\u8c6a\u5587\u82b1\u679d"
+      }
     },
     "Malamar": {
-      "codename": "687"
+      "codename": "687",
+      "locale": {
+        "fr": "Sepiatroce",
+        "de": "Calamanero",
+        "ko": "\uce7c\ub77c\ub9c8\ub124\ub85c",
+        "ja": "\u30ab\u30e9\u30de\u30cd\u30ed",
+        "zh_CN": "\u4e4c\u8d3c\u738b",
+        "zh_TW": "\u70cf\u8cca\u738b"
+      }
     },
     "Binacle": {
-      "codename": "688"
+      "codename": "688",
+      "locale": {
+        "fr": "Opermine",
+        "de": "Bithora",
+        "ko": "\uac70\ubd81\uc190\uc190",
+        "ja": "\u30ab\u30e1\u30c6\u30c6",
+        "zh_CN": "\u9f9f\u811a\u811a",
+        "zh_TW": "\u9f9c\u8173\u8173"
+      }
     },
     "Barbaracle": {
-      "codename": "689"
+      "codename": "689",
+      "locale": {
+        "fr": "Golgopathe",
+        "de": "Thanathora",
+        "ko": "\uac70\ubd81\uc190\ub370\uc2a4",
+        "ja": "\u30ac\u30e1\u30ce\u30c7\u30b9",
+        "zh_CN": "\u9f9f\u8db3\u5de8\u94e0",
+        "zh_TW": "\u9f9c\u8db3\u5de8\u93a7"
+      }
     },
     "Skrelp": {
-      "codename": "690"
+      "codename": "690",
+      "locale": {
+        "fr": "Venalgue",
+        "de": "Algitt",
+        "ko": "\uc218\ub808\uae30",
+        "ja": "\u30af\u30ba\u30e2\u30fc",
+        "zh_CN": "\u5783\u5783\u85fb",
+        "zh_TW": "\u5783\u5783\u85fb"
+      }
     },
     "Dragalge": {
-      "codename": "691"
+      "codename": "691",
+      "locale": {
+        "fr": "Kravarech",
+        "de": "Tandrak",
+        "ko": "\ub4dc\ub798\uce84",
+        "ja": "\u30c9\u30e9\u30df\u30c9\u30ed",
+        "zh_CN": "\u6bd2\u62c9\u871c\u59ae",
+        "zh_TW": "\u6bd2\u62c9\u871c\u59ae"
+      }
     },
     "Clauncher": {
-      "codename": "692"
+      "codename": "692",
+      "locale": {
+        "fr": "Flingouste",
+        "de": "Scampisto",
+        "ko": "\uc644\ucca0\ud3ec",
+        "ja": "\u30a6\u30c7\u30c3\u30dd\u30a6",
+        "zh_CN": "\u94c1\u81c2\u67aa\u867e",
+        "zh_TW": "\u9435\u81c2\u69cd\u8766"
+      }
     },
     "Clawitzer": {
-      "codename": "693"
+      "codename": "693",
+      "locale": {
+        "fr": "Gamblast",
+        "de": "Wummer",
+        "ko": "\ube14\ub85c\uc2a4\ud130",
+        "ja": "\u30d6\u30ed\u30b9\u30bf\u30fc",
+        "zh_CN": "\u94a2\u70ae\u81c2\u867e",
+        "zh_TW": "\u92fc\u7832\u81c2\u8766"
+      }
     },
     "Helioptile": {
-      "codename": "694"
+      "codename": "694",
+      "locale": {
+        "fr": "Galvaran",
+        "de": "Eguana",
+        "ko": "\ubaa9\ub3c4\ub9ac\ud0a4\ud154",
+        "ja": "\u30a8\u30ea\u30ad\u30c6\u30eb",
+        "zh_CN": "\u4f1e\u7535\u8725",
+        "zh_TW": "\u5098\u96fb\u8725"
+      }
     },
     "Heliolisk": {
-      "codename": "695"
+      "codename": "695",
+      "locale": {
+        "fr": "Iguolta",
+        "de": "Elezard",
+        "ko": "\uc77c\ub808\ub3c4\ub9ac\uc790\ub4dc",
+        "ja": "\u30a8\u30ec\u30b6\u30fc\u30c9",
+        "zh_CN": "\u7535\u4f1e\u67e5\u7279",
+        "zh_TW": "\u96fb\u5098\u67e5\u7279"
+      }
     },
     "Tyrunt": {
-      "codename": "696"
+      "codename": "696",
+      "locale": {
+        "fr": "Ptyranidur",
+        "de": "Balgoras",
+        "ko": "\ud2f0\uace0\ub77c\uc2a4",
+        "ja": "\u30c1\u30b4\u30e9\u30b9",
+        "zh_CN": "\u5b9d\u5b9d\u66b4\u9f99",
+        "zh_TW": "\u5bf6\u5bf6\u66b4\u9f8d"
+      }
     },
     "Tyrantrum": {
-      "codename": "697"
+      "codename": "697",
+      "locale": {
+        "fr": "Rexillius",
+        "de": "Monargoras",
+        "ko": "\uacac\uace0\ub77c\uc2a4",
+        "ja": "\u30ac\u30c1\u30b4\u30e9\u30b9",
+        "zh_CN": "\u602a\u989a\u9f99",
+        "zh_TW": "\u602a\u984e\u9f8d"
+      }
     },
     "Amaura": {
-      "codename": "698"
+      "codename": "698",
+      "locale": {
+        "fr": "Amagara",
+        "de": "Amarino",
+        "ko": "\uc544\ub9c8\ub8e8\uc2a4",
+        "ja": "\u30a2\u30de\u30eb\u30b9",
+        "zh_CN": "\u51b0\u96ea\u9f99",
+        "zh_TW": "\u51b0\u96ea\u9f8d"
+      }
     },
     "Aurorus": {
-      "codename": "699"
+      "codename": "699",
+      "locale": {
+        "fr": "Dragmara",
+        "de": "Amagarga",
+        "ko": "\uc544\ub9c8\ub8e8\ub974\uac00",
+        "ja": "\u30a2\u30de\u30eb\u30eb\u30ac",
+        "zh_CN": "\u51b0\u96ea\u5de8\u9f99",
+        "zh_TW": "\u51b0\u96ea\u5de8\u9f8d"
+      }
     },
     "Sylveon": {
-      "codename": "700"
+      "codename": "700",
+      "locale": {
+        "fr": "Nymphali",
+        "de": "Feelinara",
+        "ko": "\ub2d8\ud53c\uc544",
+        "ja": "\u30cb\u30f3\u30d5\u30a3\u30a2",
+        "zh_CN": "\u4ed9\u5b50\u7cbe\u7075",
+        "zh_TW": "\u4ed9\u5b50\u7cbe\u9748"
+      }
     },
     "Hawlucha": {
-      "codename": "701"
+      "codename": "701",
+      "locale": {
+        "fr": "Brutalibr\u00e9",
+        "de": "Resladero",
+        "ko": "\ub8e8\ucc28\ubd88",
+        "ja": "\u30eb\u30c1\u30e3\u30d6\u30eb",
+        "zh_CN": "\u6218\u6597\u98de\u9e1f",
+        "zh_TW": "\u6230\u9b25\u98db\u9ce5"
+      }
     },
     "Dedenne": {
-      "codename": "702"
+      "codename": "702",
+      "locale": {
+        "fr": "Dedenne",
+        "de": "Dedenne",
+        "ko": "\ub370\ub374\ub124",
+        "ja": "\u30c7\u30c7\u30f3\u30cd",
+        "zh_CN": "\u549a\u549a\u9f20",
+        "zh_TW": "\u549a\u549a\u9f20"
+      }
     },
     "Carbink": {
-      "codename": "703"
+      "codename": "703",
+      "locale": {
+        "fr": "Strassie",
+        "de": "Rocara",
+        "ko": "\uba5c\ub9ac\uc2dc",
+        "ja": "\u30e1\u30ec\u30b7\u30fc",
+        "zh_CN": "\u5c0f\u788e\u94bb",
+        "zh_TW": "\u5c0f\u788e\u947d"
+      }
     },
     "Goomy": {
-      "codename": "704"
+      "codename": "704",
+      "locale": {
+        "fr": "Mucuscule",
+        "de": "Viscora",
+        "ko": "\ubbf8\ub044\uba54\ub77c",
+        "ja": "\u30cc\u30e1\u30e9",
+        "zh_CN": "\u9ecf\u9ecf\u5b9d",
+        "zh_TW": "\u9ecf\u9ecf\u5bf6"
+      }
     },
     "Sliggoo": {
-      "codename": "705"
+      "codename": "705",
+      "locale": {
+        "fr": "Colimucus",
+        "de": "Viscargot",
+        "ko": "\ubbf8\ub044\ub124\uc77c",
+        "ja": "\u30cc\u30e1\u30a4\u30eb",
+        "zh_CN": "\u9ecf\u7f8e\u4f0a\u513f",
+        "zh_TW": "\u9ecf\u7f8e\u4f0a\u5152"
+      }
     },
     "Goodra": {
-      "codename": "706"
+      "codename": "706",
+      "locale": {
+        "fr": "Muplodocus",
+        "de": "Viscogon",
+        "ko": "\ubbf8\ub044\ub798\uace4 ",
+        "ja": "\u30cc\u30e1\u30eb\u30b4\u30f3",
+        "zh_CN": "\u9ecf\u7f8e\u9f99",
+        "zh_TW": "\u9ecf\u7f8e\u9732\u9f8d"
+      }
     },
     "Klefki": {
-      "codename": "707"
+      "codename": "707",
+      "locale": {
+        "fr": "Trousselin",
+        "de": "Clavion",
+        "ko": "\ud074\ub808\ud53c",
+        "ja": "\u30af\u30ec\u30c3\u30d5\u30a3",
+        "zh_CN": "\u94a5\u5708\u5152",
+        "zh_TW": "\u9470\u5708\u5152"
+      }
     },
     "Phantump": {
-      "codename": "708"
+      "codename": "708",
+      "locale": {
+        "fr": "Broc\u00e9l\u00f4me",
+        "de": "Paragoni",
+        "ko": "\ub098\ubaa9\ub839",
+        "ja": "\u30dc\u30af\u30ec\u30fc",
+        "zh_CN": "\u5c0f\u6728\u7075",
+        "zh_TW": "\u5c0f\u6728\u9748"
+      }
     },
     "Trevenant": {
-      "codename": "709"
+      "codename": "709",
+      "locale": {
+        "fr": "Dess\u00e9liande",
+        "de": "Trombork",
+        "ko": "\ub300\ub85c\ud2b8",
+        "ja": "\u30aa\u30fc\u30ed\u30c3\u30c8",
+        "zh_CN": "\u673d\u6728\u5996",
+        "zh_TW": "\u673d\u6728\u5996"
+      }
     },
     "Pumpkaboo": {
-      "codename": "710"
+      "codename": "710",
+      "locale": {
+        "fr": "Pitrouille",
+        "de": "Irrbis",
+        "ko": "\ud638\ubc14\uadc0",
+        "ja": "\u30d0\u30b1\u30c3\u30c1\u30e3",
+        "zh_CN": "\u5357\u74dc\u7cbe",
+        "zh_TW": "\u5357\u74dc\u7cbe"
+      }
     },
     "Gourgeist": {
-      "codename": "711"
+      "codename": "711",
+      "locale": {
+        "fr": "Banshitrouye",
+        "de": "Pumpdjinn",
+        "ko": "\ud38c\ud0a8\uc778",
+        "ja": "\u30d1\u30f3\u30d7\u30b8\u30f3",
+        "zh_CN": "\u5357\u74dc\u602a\u4eba",
+        "zh_TW": "\u5357\u74dc\u602a\u4eba"
+      }
     },
     "Bergmite": {
-      "codename": "712"
+      "codename": "712",
+      "locale": {
+        "fr": "Grela\u00e7on",
+        "de": "Arktip",
+        "ko": "\uaf41\uc5b4\ub984",
+        "ja": "\u30ab\u30c1\u30b3\u30fc\u30eb",
+        "zh_CN": "\u51b0\u5b9d",
+        "zh_TW": "\u51b0\u5bf6"
+      }
     },
     "Avalugg": {
-      "codename": "713"
+      "codename": "713",
+      "locale": {
+        "fr": "S\u00e9racrawl",
+        "de": "Arktilas",
+        "ko": "\ud06c\ub808\ubca0\uc774\uc2a4",
+        "ja": "\u30af\u30ec\u30d9\u30fc\u30b9",
+        "zh_CN": "\u51b0\u5ca9\u602a",
+        "zh_TW": "\u51b0\u5ca9\u602a"
+      }
     },
     "Noibat": {
-      "codename": "714"
+      "codename": "714",
+      "locale": {
+        "fr": "Sonistrelle",
+        "de": "eF-eM",
+        "ko": "\uc74c\ubc43",
+        "ja": "\u30aa\u30f3\u30d0\u30c3\u30c8",
+        "zh_CN": "\u55e1\u8760",
+        "zh_TW": "\u55e1\u8760"
+      }
     },
     "Noivern": {
-      "codename": "715"
+      "codename": "715",
+      "locale": {
+        "fr": "Bruyverne",
+        "de": "UHaFnir",
+        "ko": "\uc74c\ubc88",
+        "ja": "\u30aa\u30f3\u30d0\u30fc\u30f3",
+        "zh_CN": "\u97f3\u6ce2\u9f99",
+        "zh_TW": "\u97f3\u6ce2\u9f8d"
+      }
     },
     "Xerneas": {
-      "codename": "716"
+      "codename": "716",
+      "locale": {
+        "fr": "Xerneas",
+        "de": "Xerneas",
+        "ko": "\uc81c\ub974\ub124\uc544\uc2a4",
+        "ja": "\u30bc\u30eb\u30cd\u30a2\u30b9",
+        "zh_CN": "\u54f2\u5c14\u5c3c\u4e9a\u65af",
+        "zh_TW": "\u54f2\u723e\u5c3c\u4e9e\u65af"
+      }
     },
     "Yveltal": {
-      "codename": "717"
+      "codename": "717",
+      "locale": {
+        "fr": "Yveltal",
+        "de": "Yveltal",
+        "ko": "\uc774\ubca8\ud0c0\ub974",
+        "ja": "\u30a4\u30d9\u30eb\u30bf\u30eb",
+        "zh_CN": "\u4f0a\u88f4\u5c14\u5854\u5c14",
+        "zh_TW": "\u4f0a\u88f4\u723e\u5854\u723e"
+      }
     },
     "Zygarde": {
-      "codename": "718"
+      "codename": "718",
+      "locale": {
+        "fr": "Zygarde",
+        "de": "Zygarde",
+        "ko": "\uc9c0\uac00\ub974\ub370",
+        "ja": "\u30b8\u30ac\u30eb\u30c7",
+        "zh_CN": "\u57fa\u683c\u5c14\u5fb7",
+        "zh_TW": "\u57fa\u683c\u723e\u5fb7"
+      }
     },
     "Diancie": {
-      "codename": "719"
+      "codename": "719",
+      "locale": {
+        "fr": "Diancie",
+        "de": "Diancie",
+        "ko": "\ub514\uc548\uc2dc",
+        "ja": "\u30c7\u30a3\u30a2\u30f3\u30b7\u30fc",
+        "zh_CN": "\u8482\u5b89\u5e0c",
+        "zh_TW": "\u8482\u5b89\u5e0c"
+      }
     },
     "Hoopa": {
-      "codename": "720"
+      "codename": "720",
+      "locale": {
+        "fr": "Hoopa",
+        "de": "Hoopa",
+        "ko": "\ud6c4\ud30c",
+        "ja": "\u30d5\u30fc\u30d1",
+        "zh_CN": "\u80e1\u5e15",
+        "zh_TW": "\u80e1\u5e15"
+      }
     },
     "Volcanion": {
-      "codename": "721"
+      "codename": "721",
+      "locale": {
+        "fr": "Volcanion",
+        "de": "Volcanion",
+        "ko": "\ubcfc\ucf00\ub2c8\uc628",
+        "ja": "\u30dc\u30eb\u30b1\u30cb\u30aa\u30f3",
+        "zh_CN": "\u6ce2\u5c14\u51ef\u5c3c\u6069",
+        "zh_TW": "\u6ce2\u723e\u51f1\u5c3c\u6069"
+      }
     },
     "Rowlet": {
-      "codename": "722"
+      "codename": "722",
+      "locale": {
+        "fr": "Brindibou",
+        "de": "Bauz",
+        "ko": "\ub098\ubab0\ube7c\ubbf8",
+        "ja": "\u30e2\u30af\u30ed\u30fc",
+        "zh_CN": "\u6728\u6728\u67ad",
+        "zh_TW": "\u6728\u6728\u689f"
+      }
     },
     "Dartrix": {
-      "codename": "723"
+      "codename": "723",
+      "locale": {
+        "fr": "Effl\u00e8che",
+        "de": "Arboretoss",
+        "ko": "\ube7c\ubbf8\uc2a4\ub85c\uc6b0",
+        "ja": "\u30d5\u30af\u30b9\u30ed\u30fc",
+        "zh_CN": "\u6295\u7fbd\u67ad",
+        "zh_TW": "\u6295\u7fbd\u689f"
+      }
     },
     "Decidueye": {
-      "codename": "724"
+      "codename": "724",
+      "locale": {
+        "fr": "Arch\u00e9duc",
+        "de": "Silvarro",
+        "ko": "\ubaa8\ud06c\ub098\uc774\ud37c",
+        "ja": "\u30b8\u30e5\u30ca\u30a4\u30d1\u30fc",
+        "zh_CN": "\u72d9\u5c04\u6811\u67ad",
+        "zh_TW": "\u72d9\u5c04\u6a39\u689f"
+      }
     },
     "Litten": {
-      "codename": "725"
+      "codename": "725",
+      "locale": {
+        "fr": "Flamiaou",
+        "de": "Flamiau",
+        "ko": "\ub0d0\uc624\ubd88",
+        "ja": "\u30cb\u30e3\u30d3\u30fc",
+        "zh_CN": "\u706b\u6591\u55b5",
+        "zh_TW": "\u706b\u6591\u55b5"
+      }
     },
     "Torracat": {
-      "codename": "726"
+      "codename": "726",
+      "locale": {
+        "fr": "Matoufeu",
+        "de": "Miezunder",
+        "ko": "\ub0d0\uc624\ud788\ud2b8",
+        "ja": "\u30cb\u30e3\u30d2\u30fc\u30c8",
+        "zh_CN": "\u708e\u70ed\u55b5",
+        "zh_TW": "\u708e\u71b1\u55b5"
+      }
     },
     "Incineroar": {
-      "codename": "727"
+      "codename": "727",
+      "locale": {
+        "fr": "F\u00e9linferno",
+        "de": "Fuegro",
+        "ko": "\uc5b4\ud765\uc5fc",
+        "ja": "\u30ac\u30aa\u30ac\u30a8\u30f3",
+        "zh_CN": "\u70bd\u7130\u5486\u54ee\u864e",
+        "zh_TW": "\u71be\u7130\u5486\u54ee\u864e"
+      }
     },
     "Popplio": {
-      "codename": "728"
+      "codename": "728",
+      "locale": {
+        "fr": "Otaquin",
+        "de": "Robball",
+        "ko": "\ub204\ub9ac\uacf5",
+        "ja": "\u30a2\u30b7\u30de\u30ea",
+        "zh_CN": "\u7403\u7403\u6d77\u7345",
+        "zh_TW": "\u7403\u7403\u6d77\u7345"
+      }
     },
     "Brionne": {
-      "codename": "729"
+      "codename": "729",
+      "locale": {
+        "fr": "Otarlette",
+        "de": "Marikeck",
+        "ko": "\ud0a4\uc694\uacf5",
+        "ja": "\u30aa\u30b7\u30e3\u30de\u30ea",
+        "zh_CN": "\u82b1\u6f3e\u6d77\u72ee",
+        "zh_TW": "\u82b1\u6f3e\u6d77\u7345"
+      }
     },
     "Primarina": {
-      "codename": "730"
+      "codename": "730",
+      "locale": {
+        "fr": "Oratoria",
+        "de": "Primarene",
+        "ko": "\ub204\ub9ac\ub808\ub290",
+        "ja": "\u30a2\u30b7\u30ec\u30fc\u30cc",
+        "zh_CN": "\u897f\u72ee\u6d77\u58ec",
+        "zh_TW": "\u897f\u7345\u6d77\u58ec"
+      }
     },
     "Pikipek": {
-      "codename": "731"
+      "codename": "731",
+      "locale": {
+        "fr": "Picassaut",
+        "de": "Peppeck",
+        "ko": "\ucf55\ucf54\uad6c\ub9ac",
+        "ja": "\u30c4\u30c4\u30b1\u30e9",
+        "zh_CN": "\u5c0f\u7b03\u513f",
+        "zh_TW": "\u5c0f\u7be4\u5152"
+      }
     },
     "Trumbeak": {
-      "codename": "732"
+      "codename": "732",
+      "locale": {
+        "fr": "Piclairon",
+        "de": "Trompeck",
+        "ko": "\ud06c\ub77c\ud30c",
+        "ja": "\u30b1\u30e9\u30e9\u30c3\u30d1",
+        "zh_CN": "\u5587\u53ed\u5544\u9e1f",
+        "zh_TW": "\u5587\u53ed\u5544\u9ce5"
+      }
     },
     "Toucannon": {
-      "codename": "733"
+      "codename": "733",
+      "locale": {
+        "fr": "Bazoucan",
+        "de": "Tukanon",
+        "ko": "\uc655\ud070\ubd80\ub9ac",
+        "ja": "\u30c9\u30c7\u30ab\u30d0\u30b7",
+        "zh_CN": "\u94f3\u5634\u5927\u9e1f",
+        "zh_TW": "\u9283\u5634\u5927\u9ce5"
+      }
     },
     "Yungoos": {
-      "codename": "734"
+      "codename": "734",
+      "locale": {
+        "fr": "Manglouton",
+        "de": "Mangunior",
+        "ko": "\uc601\uad6c\uc2a4",
+        "ja": "\u30e4\u30f3\u30b0\u30fc\u30b9",
+        "zh_CN": "\u732b\u9f2c\u5c11",
+        "zh_TW": "\u8c93\u9f2c\u5c11"
+      }
     },
     "Gumshoos": {
-      "codename": "735"
+      "codename": "735",
+      "locale": {
+        "fr": "Argouste",
+        "de": "Manguspektor",
+        "ko": "\ud615\uc0ac\uad6c\uc2a4",
+        "ja": "\u30c7\u30ab\u30b0\u30fc\u30b9",
+        "zh_CN": "\u732b\u9f2c\u63a2\u957f",
+        "zh_TW": "\u8c93\u9f2c\u63a2\u9577"
+      }
     },
     "Grubbin": {
-      "codename": "736"
+      "codename": "736",
+      "locale": {
+        "fr": "Larvibule",
+        "de": "Mabula",
+        "ko": "\ud131\uc9c0\ucda9\uc774",
+        "ja": "\u30a2\u30b4\u30b8\u30e0\u30b7",
+        "zh_CN": "\u5f3a\u989a\u9e21\u6bcd\u866b",
+        "zh_TW": "\u5f37\u984e\u96de\u6bcd\u87f2"
+      }
     },
     "Charjabug": {
-      "codename": "737"
+      "codename": "737",
+      "locale": {
+        "fr": "Chrysapile",
+        "de": "Akkup",
+        "ko": "\uc804\uc9c0\ucda9\uc774",
+        "ja": "\u30c7\u30f3\u30c2\u30e0\u30b7",
+        "zh_CN": "\u866b\u7535\u5b9d",
+        "zh_TW": "\u87f2\u96fb\u5bf6"
+      }
     },
     "Vikavolt": {
-      "codename": "738"
+      "codename": "738",
+      "locale": {
+        "fr": "Lucanon",
+        "de": "Donarion",
+        "ko": "\ud22c\uad6c\ubfcc\ub17c",
+        "ja": "\u30af\u30ef\u30ac\u30ce\u30f3",
+        "zh_CN": "\u9539\u519c\u70ae\u866b",
+        "zh_TW": "\u936c\u8fb2\u70ae\u87f2"
+      }
     },
     "Crabrawler": {
-      "codename": "739"
+      "codename": "739",
+      "locale": {
+        "fr": "Crabagarre",
+        "de": "Krabbox",
+        "ko": "\uc624\uae30\uc9c0\uac8c",
+        "ja": "\u30de\u30b1\u30f3\u30ab\u30cb",
+        "zh_CN": "\u597d\u80dc\u87f9",
+        "zh_TW": "\u597d\u52dd\u87f9"
+      }
     },
     "Crabominable": {
-      "codename": "740"
+      "codename": "740",
+      "locale": {
+        "fr": "Crabominable",
+        "de": "Krawell",
+        "ko": "\ubaa8\ub2e8\ub2e8\uac8c",
+        "ja": "\u30b1\u30b1\u30f3\u30ab\u30cb",
+        "zh_CN": "\u597d\u80dc\u6bdb\u87f9",
+        "zh_TW": "\u597d\u52dd\u6bdb\u87f9"
+      }
     },
     "Oricorio": {
-      "codename": "741"
+      "codename": "741",
+      "locale": {
+        "fr": "Plumeline",
+        "de": "Choreogel",
+        "ko": "\ucda4\ucd94\uc0c8",
+        "ja": "\u30aa\u30c9\u30ea\u30c9\u30ea",
+        "zh_CN": "\u82b1\u821e\u9e1f",
+        "zh_TW": "\u82b1\u821e\u9ce5"
+      }
     },
     "Cutiefly": {
-      "codename": "742"
+      "codename": "742",
+      "locale": {
+        "fr": "Bombydou",
+        "de": "Wommel",
+        "ko": "\uc5d0\ube14\ub9ac",
+        "ja": "\u30a2\u30d6\u30ea\u30fc",
+        "zh_CN": "\u840c\u867b",
+        "zh_TW": "\u840c\u867b"
+      }
     },
     "Ribombee": {
-      "codename": "743"
+      "codename": "743",
+      "locale": {
+        "fr": "Rubombelle",
+        "de": "Bandelby",
+        "ko": "\uc5d0\ub9ac\ubcf8",
+        "ja": "\u30a2\u30d6\u30ea\u30dc\u30f3",
+        "zh_CN": "\u8776\u7ed3\u840c\u867b",
+        "zh_TW": "\u8776\u7d50\u840c\u867b"
+      }
     },
     "Rockruff": {
-      "codename": "744"
+      "codename": "744",
+      "locale": {
+        "fr": "Rocabot",
+        "de": "Wuffels",
+        "ko": "\uc554\uba4d\uc774",
+        "ja": "\u30a4\u30ef\u30f3\u30b3",
+        "zh_CN": "\u5ca9\u72d7\u72d7",
+        "zh_TW": "\u5ca9\u72d7\u72d7"
+      }
     },
     "Lycanroc": {
-      "codename": "745"
+      "codename": "745",
+      "locale": {
+        "fr": "Lougaroc",
+        "de": "Wolwerock",
+        "ko": "\ub8e8\uac00\ub8e8\uc554",
+        "ja": "\u30eb\u30ac\u30eb\u30ac\u30f3",
+        "zh_CN": "\u9b03\u5ca9\u72fc\u4eba",
+        "zh_TW": "\u9b03\u5ca9\u72fc\u4eba"
+      }
     },
     "Wishiwashi": {
-      "codename": "746"
+      "codename": "746",
+      "locale": {
+        "fr": "Froussardine",
+        "de": "Lusardin",
+        "ko": "\uc57d\uc5b4\ub9ac",
+        "ja": "\u30e8\u30ef\u30b7",
+        "zh_CN": "\u5f31\u4e01\u9c7c",
+        "zh_TW": "\u5f31\u4e01\u9b5a"
+      }
     },
     "Mareanie": {
-      "codename": "747"
+      "codename": "747",
+      "locale": {
+        "fr": "Vorast\u00e9rie",
+        "de": "Garstella",
+        "ko": "\uc2dc\ub9c8\uc0ac\ub9ac",
+        "ja": "\u30d2\u30c9\u30a4\u30c7",
+        "zh_CN": "\u597d\u574f\u661f",
+        "zh_TW": "\u597d\u58de\u661f"
+      }
     },
     "Toxapex": {
-      "codename": "748"
+      "codename": "748",
+      "locale": {
+        "fr": "Pr\u00e9dast\u00e9rie",
+        "de": "Aggrostella",
+        "ko": "\ub354\uc2dc\ub9c8\uc0ac\ub9ac",
+        "ja": "\u30c9\u30d2\u30c9\u30a4\u30c7",
+        "zh_CN": "\u8d85\u574f\u661f",
+        "zh_TW": "\u8d85\u58de\u661f"
+      }
     },
     "Mudbray": {
-      "codename": "749"
+      "codename": "749",
+      "locale": {
+        "fr": "Tiboudet",
+        "de": "Pampuli",
+        "ko": "\uba38\ub4dc\ub098\uae30",
+        "ja": "\u30c9\u30ed\u30d0\u30f3\u30b3",
+        "zh_CN": "\u6ce5\u9a74\u4ed4",
+        "zh_TW": "\u6ce5\u9a62\u4ed4"
+      }
     },
     "Mudsdale": {
-      "codename": "750"
+      "codename": "750",
+      "locale": {
+        "fr": "Bourrinos",
+        "de": "Pampross",
+        "ko": "\ub9cc\ub9c8\ub4dc",
+        "ja": "\u30d0\u30f3\u30d0\u30c9\u30ed",
+        "zh_CN": "\u91cd\u6ce5\u633d\u9a6c",
+        "zh_TW": "\u91cd\u6ce5\u633d\u99ac"
+      }
     },
     "Dewpider": {
-      "codename": "751"
+      "codename": "751",
+      "locale": {
+        "fr": "Araqua",
+        "de": "Araqua",
+        "ko": "\ubb3c\uac70\ubbf8",
+        "ja": "\u30b7\u30ba\u30af\u30e2",
+        "zh_CN": "\u6ef4\u86db",
+        "zh_TW": "\u6ef4\u86db"
+      }
     },
     "Araquanid": {
-      "codename": "752"
+      "codename": "752",
+      "locale": {
+        "fr": "Tarenbulle",
+        "de": "Aranestro",
+        "ko": "\uae68\ube44\ubb3c\uac70\ubbf8",
+        "ja": "\u30aa\u30cb\u30b7\u30ba\u30af\u30e2",
+        "zh_CN": "\u6ef4\u86db\u9738",
+        "zh_TW": "\u6ef4\u86db\u9738"
+      }
     },
     "Fomantis": {
-      "codename": "753"
+      "codename": "753",
+      "locale": {
+        "fr": "Mimantis",
+        "de": "Imantis",
+        "ko": "\uc9dc\ub791\ub791",
+        "ja": "\u30ab\u30ea\u30ad\u30ea",
+        "zh_CN": "\u4f2a\u87b3\u8349",
+        "zh_TW": "\u507d\u87b3\u8349"
+      }
     },
     "Lurantis": {
-      "codename": "754"
+      "codename": "754",
+      "locale": {
+        "fr": "Floramantis",
+        "de": "Mantidea",
+        "ko": "\ub77c\ub780\ud2f0\uc2a4",
+        "ja": "\u30e9\u30e9\u30f3\u30c6\u30b9",
+        "zh_CN": "\u5170\u87b3\u82b1",
+        "zh_TW": "\u862d\u87b3\u82b1"
+      }
     },
     "Morelull": {
-      "codename": "755"
+      "codename": "755",
+      "locale": {
+        "fr": "Spododo",
+        "de": "Bubungus",
+        "ko": "\uc790\ub9c8\uc288",
+        "ja": "\u30cd\u30de\u30b7\u30e5",
+        "zh_CN": "\u7761\u7761\u83c7",
+        "zh_TW": "\u7761\u7761\u83c7"
+      }
     },
     "Shiinotic": {
-      "codename": "756"
+      "codename": "756",
+      "locale": {
+        "fr": "Lampignon",
+        "de": "Lamellux",
+        "ko": "\ub9c8\uc170\uc774\ub4dc",
+        "ja": "\u30de\u30b7\u30a7\u30fc\u30c9",
+        "zh_CN": "\u706f\u7f69\u591c\u83c7",
+        "zh_TW": "\u71c8\u7f69\u591c\u83c7"
+      }
     },
     "Salandit": {
-      "codename": "757"
+      "codename": "757",
+      "locale": {
+        "fr": "Tritox",
+        "de": "Molunk",
+        "ko": "\uc57c\ub3c4\ub1fd",
+        "ja": "\u30e4\u30c8\u30a6\u30e2\u30ea",
+        "zh_CN": "\u591c\u76d7\u706b\u8725",
+        "zh_TW": "\u591c\u76dc\u706b\u8725"
+      }
     },
     "Salazzle": {
-      "codename": "758"
+      "codename": "758",
+      "locale": {
+        "fr": "Malamandre",
+        "de": "Amfira",
+        "ko": "\uc5fc\ub274\ud2b8",
+        "ja": "\u30a8\u30f3\u30cb\u30e5\u30fc\u30c8",
+        "zh_CN": "\u7130\u540e\u8725",
+        "zh_TW": "\u7130\u540e\u8725"
+      }
     },
     "Stufful": {
-      "codename": "759"
+      "codename": "759",
+      "locale": {
+        "fr": "Nounourson",
+        "de": "Velursi",
+        "ko": "\ud3ec\uacf0\uacf0",
+        "ja": "\u30cc\u30a4\u30b3\u30b0\u30de",
+        "zh_CN": "\u7ae5\u5076\u718a",
+        "zh_TW": "\u7ae5\u5076\u718a"
+      }
     },
     "Bewear": {
-      "codename": "760"
+      "codename": "760",
+      "locale": {
+        "fr": "Chelours",
+        "de": "Kosturso",
+        "ko": "\uc774\ube10\uacf0",
+        "ja": "\u30ad\u30c6\u30eb\u30b0\u30de",
+        "zh_CN": "\u7a7f\u7740\u718a",
+        "zh_TW": "\u7a7f\u8457\u718a"
+      }
     },
     "Bounsweet": {
-      "codename": "761"
+      "codename": "761",
+      "locale": {
+        "fr": "Croquine",
+        "de": "Frubberl",
+        "ko": "\ub2ec\ucf64\uc544",
+        "ja": "\u30a2\u30de\u30ab\u30b8",
+        "zh_CN": "\u751c\u7af9\u7af9",
+        "zh_TW": "\u751c\u7af9\u7af9"
+      }
     },
     "Steenee": {
-      "codename": "762"
+      "codename": "762",
+      "locale": {
+        "fr": "Candine",
+        "de": "Frubaila",
+        "ko": "\ub2ec\ubb34\ub9ac\ub098",
+        "ja": "\u30a2\u30de\u30de\u30a4\u30b3",
+        "zh_CN": "\u751c\u821e\u59ae",
+        "zh_TW": "\u751c\u821e\u59ae"
+      }
     },
     "Tsareena": {
-      "codename": "763"
+      "codename": "763",
+      "locale": {
+        "fr": "Sucreine",
+        "de": "Fruyal",
+        "ko": "\ub2ec\ucf54\ud038",
+        "ja": "\u30a2\u30de\u30fc\u30b8\u30e7",
+        "zh_CN": "\u751c\u51b7\u7f8e\u540e",
+        "zh_TW": "\u751c\u51b7\u7f8e\u540e"
+      }
     },
     "Comfey": {
-      "codename": "764"
+      "codename": "764",
+      "locale": {
+        "fr": "Gu\u00e9rilande",
+        "de": "Curelei",
+        "ko": "\ud050\uc544\ub9c1",
+        "ja": "\u30ad\u30e5\u30ef\u30ef\u30fc",
+        "zh_CN": "\u82b1\u7597\u73af\u73af",
+        "zh_TW": "\u82b1\u7642\u74b0\u74b0"
+      }
     },
     "Oranguru": {
-      "codename": "765"
+      "codename": "765",
+      "locale": {
+        "fr": "Gouroutan",
+        "de": "Kommandutan",
+        "ko": "\ud558\ub791\uc6b0\ud0c4",
+        "ja": "\u30e4\u30ec\u30e6\u30fc\u30bf\u30f3",
+        "zh_CN": "\u667a\u6325\u7329",
+        "zh_TW": "\u667a\u63ee\u7329"
+      }
     },
     "Passimian": {
-      "codename": "766"
+      "codename": "766",
+      "locale": {
+        "fr": "Quartermac",
+        "de": "Quartermak",
+        "ko": "\ub0b4\ub358\uc22d\uc774",
+        "ja": "\u30ca\u30b2\u30c4\u30b1\u30b5\u30eb",
+        "zh_CN": "\u6295\u63b7\u7334",
+        "zh_TW": "\u6295\u64f2\u7334"
+      }
     },
     "Wimpod": {
-      "codename": "767"
+      "codename": "767",
+      "locale": {
+        "fr": "Sovkipou",
+        "de": "Rei\u00dflaus",
+        "ko": "\uaf2c\uc2dc\ub808",
+        "ja": "\u30b3\u30bd\u30af\u30e0\u30b7",
+        "zh_CN": "\u80c6\u5c0f\u866b",
+        "zh_TW": "\u81bd\u5c0f\u87f2"
+      }
     },
     "Golisopod": {
-      "codename": "768"
+      "codename": "768",
+      "locale": {
+        "fr": "Sarmura\u00ef",
+        "de": "Tectass",
+        "ko": "\uac11\uc8fc\ubb34\uc0ac",
+        "ja": "\u30b0\u30bd\u30af\u30e0\u30b7\u30e3",
+        "zh_CN": "\u5177\u7532\u6b66\u8005",
+        "zh_TW": "\u5177\u7532\u6b66\u8005"
+      }
     },
     "Sandygast": {
-      "codename": "769"
+      "codename": "769",
+      "locale": {
+        "fr": "Bacabouh",
+        "de": "Sankabuh",
+        "ko": "\ubaa8\ub798\uafcd",
+        "ja": "\u30b9\u30ca\u30d0\u30a1",
+        "zh_CN": "\u6c99\u4e18\u5a03",
+        "zh_TW": "\u6c99\u4e18\u5a03"
+      }
     },
     "Palossand": {
-      "codename": "770"
+      "codename": "770",
+      "locale": {
+        "fr": "Tr\u00e9passable",
+        "de": "Colossand",
+        "ko": "\ubaa8\ub798\uc131\uc774\ub2f9",
+        "ja": "\u30b7\u30ed\u30c7\u30b9\u30ca",
+        "zh_CN": "\u566c\u6c99\u5821\u7237",
+        "zh_TW": "\u566c\u6c99\u5821\u723a"
+      }
     },
     "Pyukumuku": {
-      "codename": "771"
+      "codename": "771",
+      "locale": {
+        "fr": "Concombaffe",
+        "de": "Gufa",
+        "ko": "\ud574\ubb34\uae30",
+        "ja": "\u30ca\u30de\u30b3\u30d6\u30b7",
+        "zh_CN": "\u62f3\u6d77\u53c2",
+        "zh_TW": "\u62f3\u6d77\u53c3"
+      }
     },
     "Type: Null": {
-      "codename": "772"
+      "codename": "772",
+      "locale": {
+        "fr": "Type:0",
+        "de": "Typ:Null",
+        "ko": "\ud0c0\uc785:\ub110",
+        "ja": "\u30bf\u30a4\u30d7\uff1a\u30cc\u30eb",
+        "zh_CN": "\u5c5e\u6027\uff1a\u7a7a",
+        "zh_TW": "\u5c6c\u6027\uff1a\u7a7a"
+      }
     },
     "Silvally": {
-      "codename": "773"
+      "codename": "773",
+      "locale": {
+        "fr": "Silvalli\u00e9",
+        "de": "Amigento",
+        "ko": "\uc2e4\ubc84\ub514",
+        "ja": "\u30b7\u30eb\u30f4\u30a1\u30c7\u30a3",
+        "zh_CN": "\u94f6\u4f34\u6218\u517d",
+        "zh_TW": "\u9280\u4f34\u6230\u7378"
+      }
     },
     "Minior": {
-      "codename": "774"
+      "codename": "774",
+      "locale": {
+        "fr": "M\u00e9t\u00e9no",
+        "de": "Meteno",
+        "ko": "\uba54\ud14c\ub178",
+        "ja": "\u30e1\u30c6\u30ce",
+        "zh_CN": "\u5c0f\u9668\u661f",
+        "zh_TW": "\u5c0f\u9695\u661f"
+      }
     },
     "Komala": {
-      "codename": "775"
+      "codename": "775",
+      "locale": {
+        "fr": "Dodoala",
+        "de": "Koalelu",
+        "ko": "\uc790\ub9d0\ub77c",
+        "ja": "\u30cd\u30c3\u30b3\u30a2\u30e9",
+        "zh_CN": "\u6811\u6795\u5c3e\u718a",
+        "zh_TW": "\u6a39\u6795\u5c3e\u718a"
+      }
     },
     "Turtonator": {
-      "codename": "776"
+      "codename": "776",
+      "locale": {
+        "fr": "Boumata",
+        "de": "Tortunator",
+        "ko": "\ud3ed\uac70\ubd81\uc2a4",
+        "ja": "\u30d0\u30af\u30ac\u30e1\u30b9",
+        "zh_CN": "\u7206\u7130\u9f9f\u517d",
+        "zh_TW": "\u7206\u7130\u9f9c\u7378"
+      }
     },
     "Togedemaru": {
-      "codename": "777"
+      "codename": "777",
+      "locale": {
+        "fr": "Togedemaru",
+        "de": "Togedemaru",
+        "ko": "\ud1a0\uac8c\ub370\ub9c8\ub8e8",
+        "ja": "\u30c8\u30b2\u30c7\u30de\u30eb",
+        "zh_CN": "\u6258\u6208\u5fb7\u739b\u5c14",
+        "zh_TW": "\u6258\u6208\u5fb7\u746a\u723e"
+      }
     },
     "Mimikyu": {
-      "codename": "778"
+      "codename": "778",
+      "locale": {
+        "fr": "Mimiqui",
+        "de": "Mimigma",
+        "ko": "\ub530\ub77c\ud050",
+        "ja": "\u30df\u30df\u30c3\u30ad\u30e5",
+        "zh_CN": "\u8c1c\u62df\uff31",
+        "zh_TW": "\u8b0e\u64ec\uff31"
+      }
     },
     "Bruxish": {
-      "codename": "779"
+      "codename": "779",
+      "locale": {
+        "fr": "Denticrisse",
+        "de": "Knirfish",
+        "ko": "\uce58\uac08\uae30",
+        "ja": "\u30cf\u30ae\u30ae\u30b7\u30ea",
+        "zh_CN": "\u78e8\u7259\u5f69\u76ae\u9c7c",
+        "zh_TW": "\u78e8\u7259\u5f69\u76ae\u9b5a"
+      }
     },
     "Drampa": {
-      "codename": "780"
+      "codename": "780",
+      "locale": {
+        "fr": "Dra\u00efeul",
+        "de": "Sen-Long",
+        "ko": "\ud560\ube44\ub871",
+        "ja": "\u30b8\u30b8\u30fc\u30ed\u30f3",
+        "zh_CN": "\u8001\u7fc1\u9f99",
+        "zh_TW": "\u8001\u7fc1\u9f8d"
+      }
     },
     "Dhelmise": {
-      "codename": "781"
+      "codename": "781",
+      "locale": {
+        "fr": "Sinistrail",
+        "de": "Moruda",
+        "ko": "\ud0c0\ud0c0\ub95c",
+        "ja": "\u30c0\u30c0\u30ea\u30f3",
+        "zh_CN": "\u7834\u7834\u8235\u8f6e",
+        "zh_TW": "\u7834\u7834\u8235\u8f2a"
+      }
     },
     "Jangmo-o": {
-      "codename": "782"
+      "codename": "782",
+      "locale": {
+        "fr": "B\u00e9b\u00e9caille",
+        "de": "Miniras",
+        "ko": "\uc9dc\ub791\uaf2c",
+        "ja": "\u30b8\u30e3\u30e9\u30b3",
+        "zh_CN": "\u5fc3\u9cde\u5b9d",
+        "zh_TW": "\u5fc3\u9c57\u5bf6"
+      }
     },
     "Hakamo-o": {
-      "codename": "783"
+      "codename": "783",
+      "locale": {
+        "fr": "\u00c9ca\u00efd",
+        "de": "Mediras",
+        "ko": "\uc9dc\ub791\uace0\uc6b0",
+        "ja": "\u30b8\u30e3\u30e9\u30f3\u30b4",
+        "zh_CN": "\u9cde\u7532\u9f99",
+        "zh_TW": "\u9c57\u7532\u9f8d"
+      }
     },
     "Kommo-o": {
-      "codename": "784"
+      "codename": "784",
+      "locale": {
+        "fr": "\u00c9ka\u00efser",
+        "de": "Grandiras",
+        "ko": "\uc9dc\ub791\uace0\uc6b0\uac70",
+        "ja": "\u30b8\u30e3\u30e9\u30e9\u30f3\u30ac",
+        "zh_CN": "\u6756\u5c3e\u9cde\u7532\u9f99",
+        "zh_TW": "\u6756\u5c3e\u9c57\u7532\u9f8d"
+      }
     },
     "Tapu Koko": {
-      "codename": "785"
+      "codename": "785",
+      "locale": {
+        "fr": "Tokorico",
+        "de": "Kapu-Riki",
+        "ko": "\uce74\ud478\uaf2c\uaf2c\uaf2d",
+        "ja": "\u30ab\u30d7\u30fb\u30b3\u30b1\u30b3",
+        "zh_CN": "\u5361\u749e\u30fb\u9e23\u9e23",
+        "zh_TW": "\u5361\u749e\u30fb\u9cf4\u9cf4"
+      }
     },
     "Tapu Lele": {
-      "codename": "786"
+      "codename": "786",
+      "locale": {
+        "fr": "Tokopiyon",
+        "de": "Kapu-Fala",
+        "ko": "\uce74\ud478\ub098\ube44\ub098",
+        "ja": "\u30ab\u30d7\u30fb\u30c6\u30c6\u30d5",
+        "zh_CN": "\u5361\u749e\u30fb\u8776\u8776",
+        "zh_TW": "\u5361\u749e\u30fb\u8776\u8776"
+      }
     },
     "Tapu Bulu": {
-      "codename": "787"
+      "codename": "787",
+      "locale": {
+        "fr": "Tokotoro",
+        "de": "Kapu-Toro",
+        "ko": "\uce74\ud478\ube0c\ub8e8\ub8e8",
+        "ja": "\u30ab\u30d7\u30fb\u30d6\u30eb\u30eb",
+        "zh_CN": "\u5361\u749e\u30fb\u54de\u54de",
+        "zh_TW": "\u5361\u749e\u30fb\u54de\u54de"
+      }
     },
     "Tapu Fini": {
-      "codename": "788"
+      "codename": "788",
+      "locale": {
+        "fr": "Tokopisco",
+        "de": "Kapu-Kime",
+        "ko": "\uce74\ud478\ub290\uc9c0\ub290",
+        "ja": "\u30ab\u30d7\u30fb\u30ec\u30d2\u30ec",
+        "zh_CN": "\u5361\u749e\u30fb\u9ccd\u9ccd",
+        "zh_TW": "\u5361\u749e\u30fb\u9c2d\u9c2d"
+      }
     },
     "Cosmog": {
-      "codename": "789"
+      "codename": "789",
+      "locale": {
+        "fr": "Cosmog",
+        "de": "Cosmog",
+        "ko": "\ucf54\uc2a4\ubaa8\uadf8",
+        "ja": "\u30b3\u30b9\u30e2\u30c3\u30b0",
+        "zh_CN": "\u79d1\u65af\u83ab\u53e4",
+        "zh_TW": "\u79d1\u65af\u83ab\u53e4"
+      }
     },
     "Cosmoem": {
-      "codename": "790"
+      "codename": "790",
+      "locale": {
+        "fr": "Cosmovum",
+        "de": "Cosmovum",
+        "ko": "\ucf54\uc2a4\ubaa8\uc6c0",
+        "ja": "\u30b3\u30b9\u30e2\u30a6\u30e0",
+        "zh_CN": "\u79d1\u65af\u83ab\u59c6",
+        "zh_TW": "\u79d1\u65af\u83ab\u59c6"
+      }
     },
     "Solgaleo": {
-      "codename": "791"
+      "codename": "791",
+      "locale": {
+        "fr": "Solgaleo",
+        "de": "Solgaleo",
+        "ko": "\uc194\uac00\ub808\uc624",
+        "ja": "\u30bd\u30eb\u30ac\u30ec\u30aa",
+        "zh_CN": "\u7d22\u5c14\u8fe6\u96f7\u6b27",
+        "zh_TW": "\u7d22\u723e\u8fe6\u96f7\u6b50"
+      }
     },
     "Lunala": {
-      "codename": "792"
+      "codename": "792",
+      "locale": {
+        "fr": "Lunala",
+        "de": "Lunala",
+        "ko": "\ub8e8\ub098\uc544\ub77c",
+        "ja": "\u30eb\u30ca\u30a2\u30fc\u30e9",
+        "zh_CN": "\u9732\u5948\u96c5\u62c9",
+        "zh_TW": "\u9732\u5948\u96c5\u62c9"
+      }
     },
     "Nihilego": {
-      "codename": "793"
+      "codename": "793",
+      "locale": {
+        "fr": "Z\u00e9ro\u00efd",
+        "de": "Anego",
+        "ko": "\ud145\ube44\ub4dc",
+        "ja": "\u30a6\u30c4\u30ed\u30a4\u30c9",
+        "zh_CN": "\u865a\u543e\u4f0a\u5fb7",
+        "zh_TW": "\u865b\u543e\u4f0a\u5fb7"
+      }
     },
     "Buzzwole": {
-      "codename": "794"
+      "codename": "794",
+      "locale": {
+        "fr": "Mouscoto",
+        "de": "Masskito",
+        "ko": "\ub9e4\uc2dc\ubd95",
+        "ja": "\u30de\u30c3\u30b7\u30d6\u30fc\u30f3",
+        "zh_CN": "\u7206\u808c\u868a",
+        "zh_TW": "\u7206\u808c\u868a"
+      }
     },
     "Pheromosa": {
-      "codename": "795"
+      "codename": "795",
+      "locale": {
+        "fr": "Cancrelove",
+        "de": "Schabelle",
+        "ko": "\ud398\ub85c\ucf54\uccb4",
+        "ja": "\u30d5\u30a7\u30ed\u30fc\u30c1\u30a7",
+        "zh_CN": "\u8d39\u6d1b\u7f8e\u8782",
+        "zh_TW": "\u8cbb\u6d1b\u7f8e\u8782"
+      }
     },
     "Xurkitree": {
-      "codename": "796"
+      "codename": "796",
+      "locale": {
+        "fr": "C\u00e2blif\u00e8re",
+        "de": "Voltriant",
+        "ko": "\uc804\uc218\ubaa9",
+        "ja": "\u30c7\u30f3\u30b8\u30e5\u30e2\u30af",
+        "zh_CN": "\u7535\u675f\u6728",
+        "zh_TW": "\u96fb\u675f\u6728"
+      }
     },
     "Celesteela": {
-      "codename": "797"
+      "codename": "797",
+      "locale": {
+        "fr": "Bamboiselle",
+        "de": "Kaguron",
+        "ko": "\ucca0\ud654\uad6c\uc57c",
+        "ja": "\u30c6\u30c3\u30ab\u30b0\u30e4",
+        "zh_CN": "\u94c1\u706b\u8f89\u591c",
+        "zh_TW": "\u9435\u706b\u8f1d\u591c"
+      }
     },
     "Kartana": {
-      "codename": "798"
+      "codename": "798",
+      "locale": {
+        "fr": "Katagami",
+        "de": "Katagami",
+        "ko": "\uc885\uc774\uc2e0\ub3c4",
+        "ja": "\u30ab\u30df\u30c4\u30eb\u30ae",
+        "zh_CN": "\u7eb8\u5fa1\u5251",
+        "zh_TW": "\u7d19\u5fa1\u528d"
+      }
     },
     "Guzzlord": {
-      "codename": "799"
+      "codename": "799",
+      "locale": {
+        "fr": "Engloutyran",
+        "de": "Schlingking",
+        "ko": "\uc545\uc2dd\ud0b9",
+        "ja": "\u30a2\u30af\u30b8\u30ad\u30f3\u30b0",
+        "zh_CN": "\u6076\u98df\u5927\u738b",
+        "zh_TW": "\u60e1\u98df\u5927\u738b"
+      }
     },
     "Necrozma": {
-      "codename": "800"
+      "codename": "800",
+      "locale": {
+        "fr": "Necrozma",
+        "de": "Necrozma",
+        "ko": "\ub124\ud06c\ub85c\uc988\ub9c8",
+        "ja": "\u30cd\u30af\u30ed\u30ba\u30de",
+        "zh_CN": "\u5948\u514b\u6d1b\u5179\u739b",
+        "zh_TW": "\u5948\u514b\u6d1b\u5179\u746a"
+      }
     },
     "Magearna": {
-      "codename": "801"
+      "codename": "801",
+      "locale": {
+        "fr": "Magearna",
+        "de": "Magearna",
+        "ko": "\ub9c8\uae30\uc544\ub098",
+        "ja": "\u30de\u30ae\u30a2\u30ca",
+        "zh_CN": "\u746a\u6a5f\u96c5\u5a1c",
+        "zh_TW": "\u746a\u6a5f\u96c5\u5a1c"
+      }
     },
     "Marshadow": {
-      "codename": "802"
+      "codename": "802",
+      "locale": {
+        "fr": "Marshadow",
+        "de": "Marshadow",
+        "ko": "\ub9c8\uc0e4\ub3c4",
+        "ja": "\u30de\u30fc\u30b7\u30e3\u30c9\u30fc",
+        "zh_CN": "\u739b\u590f\u591a",
+        "zh_TW": "\u746a\u590f\u591a"
+      }
     },
     "Poipole": {
-      "codename": "803"
+      "codename": "803",
+      "locale": {
+        "fr": "V\u00e9mini",
+        "de": "Venicro",
+        "ko": "\ubca0\ubca0\ub188",
+        "ja": "\u30d9\u30d9\u30ce\u30e0",
+        "zh_CN": "\u6bd2\u8d1d\u6bd4",
+        "zh_TW": "\u6bd2\u8c9d\u6bd4"
+      }
     },
     "Naganadel": {
-      "codename": "804"
+      "codename": "804",
+      "locale": {
+        "fr": "Mandrillon",
+        "de": "Agoyon",
+        "ko": "\uc544\uace0\uc6a9",
+        "ja": "\u30a2\u30fc\u30b4\u30e8\u30f3",
+        "zh_CN": "\u56db\u989a\u9488\u9f99",
+        "zh_TW": "\u56db\u984e\u91dd\u9f8d"
+      }
     },
     "Stakataka": {
-      "codename": "805"
+      "codename": "805",
+      "locale": {
+        "fr": "Ama-Ama",
+        "de": "Muramura",
+        "ko": "\ucc28\uace1\ucc28\uace1",
+        "ja": "\u30c4\u30f3\u30c7\u30c4\u30f3\u30c7",
+        "zh_CN": "\u5792\u78ca\u77f3",
+        "zh_TW": "\u58d8\u78ca\u77f3"
+      }
     },
     "Blacephalon": {
-      "codename": "806"
+      "codename": "806",
+      "locale": {
+        "fr": "Pierroteknik",
+        "de": "Kopplosio",
+        "ko": "\ub450\ud30c\ud321",
+        "ja": "\u30ba\u30ac\u30c9\u30fc\u30f3",
+        "zh_CN": "\u7830\u5934\u5c0f\u4e11",
+        "zh_TW": "\u7830\u982d\u5c0f\u4e11"
+      }
     },
     "Zeraora": {
-      "codename": "807"
+      "codename": "807",
+      "locale": {
+        "fr": "Zeraora",
+        "de": "Zeraora",
+        "ko": "\uc81c\ub77c\uc624\ub77c",
+        "ja": "\u30bc\u30e9\u30aa\u30e9",
+        "zh_CN": "\u6377\u62c9\u5965\u62c9",
+        "zh_TW": "\u6377\u62c9\u5967\u62c9"
+      }
     },
     "Meltan": {
-      "codename": "808"
+      "codename": "808",
+      "locale": {
+        "fr": "Meltan",
+        "de": "Meltan",
+        "ko": "\uba5c\ud0c4",
+        "ja": "\u30e1\u30eb\u30bf\u30f3",
+        "zh_CN": "\u7f8e\u5f55\u5766",
+        "zh_TW": "\u7f8e\u9304\u5766"
+      }
     },
     "Melmetal": {
-      "codename": "809"
+      "codename": "809",
+      "locale": {
+        "fr": "Melmetal",
+        "de": "Melmetal",
+        "ko": "\uba5c\uba54\ud0c8",
+        "ja": "\u30e1\u30eb\u30e1\u30bf\u30eb",
+        "zh_CN": "\u7f8e\u5f55\u6885\u5854",
+        "zh_TW": "\u7f8e\u9304\u6885\u5854"
+      }
     },
     "Grookey": {
-      "codename": "810"
+      "codename": "810",
+      "locale": {
+        "fr": "Ouistempo",
+        "de": "Chimpep",
+        "ko": "\ud765\ub098\uc22d",
+        "ja": "\u30b5\u30eb\u30ce\u30ea",
+        "zh_CN": "\u6572\u97f3\u7334",
+        "zh_TW": "\u6572\u97f3\u7334"
+      }
     },
     "Thwackey": {
-      "codename": "811"
+      "codename": "811",
+      "locale": {
+        "fr": "Badabouin",
+        "de": "Chimstix",
+        "ko": "\ucc44\ud0a4\ubabd",
+        "ja": "\u30d0\u30c1\u30f3\u30ad\u30fc",
+        "zh_CN": "\u556a\u549a\u7334",
+        "zh_TW": "\u556a\u549a\u7334"
+      }
     },
     "Rillaboom": {
-      "codename": "812"
+      "codename": "812",
+      "locale": {
+        "fr": "Gorythmic",
+        "de": "Gortrom",
+        "ko": "\uace0\ub9b4\ud0c0",
+        "ja": "\u30b4\u30ea\u30e9\u30f3\u30c0\u30fc",
+        "zh_CN": "\u8f70\u64c2\u91d1\u521a\u7329",
+        "zh_TW": "\u8f5f\u64c2\u91d1\u525b\u7329"
+      }
     },
     "Scorbunny": {
-      "codename": "813"
+      "codename": "813",
+      "locale": {
+        "fr": "Flambino",
+        "de": "Hopplo",
+        "ko": "\uc5fc\ubc84\ub2c8",
+        "ja": "\u30d2\u30d0\u30cb\u30fc",
+        "zh_CN": "\u708e\u5154\u513f",
+        "zh_TW": "\u708e\u5154\u5152"
+      }
     },
     "Raboot": {
-      "codename": "814"
+      "codename": "814",
+      "locale": {
+        "fr": "Lapyro",
+        "de": "Kickerlo",
+        "ko": "\ub798\ube44\ud48b",
+        "ja": "\u30e9\u30d3\u30d5\u30c3\u30c8",
+        "zh_CN": "\u817e\u8e74\u5c0f\u5c06",
+        "zh_TW": "\u9a30\u8e74\u5c0f\u5c07"
+      }
     },
     "Cinderace": {
-      "codename": "815"
+      "codename": "815",
+      "locale": {
+        "fr": "Pyrobut",
+        "de": "Liberlo",
+        "ko": "\uc5d0\uc774\uc2a4\ubc88",
+        "ja": "\u30a8\u30fc\u30b9\u30d0\u30fc\u30f3",
+        "zh_CN": "\u95ea\u7130\u738b\u724c",
+        "zh_TW": "\u9583\u7130\u738b\u724c"
+      }
     },
     "Sobble": {
-      "codename": "816"
+      "codename": "816",
+      "locale": {
+        "fr": "Larm\u00e9l\u00e9on",
+        "de": "Memmeon",
+        "ko": "\uc6b8\uba38\uae30",
+        "ja": "\u30e1\u30c3\u30bd\u30f3",
+        "zh_CN": "\u6cea\u773c\u8725",
+        "zh_TW": "\u6dda\u773c\u8725"
+      }
     },
     "Drizzile": {
-      "codename": "817"
+      "codename": "817",
+      "locale": {
+        "fr": "Arrozard",
+        "de": "Phlegleon",
+        "ko": "\ub204\uac94\ub808\uc628",
+        "ja": "\u30b8\u30e1\u30ec\u30aa\u30f3",
+        "zh_CN": "\u53d8\u6da9\u8725",
+        "zh_TW": "\u8b8a\u6f80\u8725"
+      }
     },
     "Inteleon": {
-      "codename": "818"
+      "codename": "818",
+      "locale": {
+        "fr": "L\u00e9zargus",
+        "de": "Intelleon",
+        "ko": "\uc778\ud154\ub9ac\ub808\uc628",
+        "ja": "\u30a4\u30f3\u30c6\u30ec\u30aa\u30f3",
+        "zh_CN": "\u5343\u9762\u907f\u5f79",
+        "zh_TW": "\u5343\u9762\u907f\u5f79"
+      }
     },
     "Skwovet": {
-      "codename": "819"
+      "codename": "819",
+      "locale": {
+        "fr": "Rongourmand",
+        "de": "Raffel",
+        "ko": "\ud0d0\ub9ac\uc2a4",
+        "ja": "\u30db\u30b7\u30ac\u30ea\u30b9",
+        "zh_CN": "\u8d2a\u5fc3\u6817\u9f20",
+        "zh_TW": "\u8caa\u5fc3\u6817\u9f20"
+      }
     },
     "Greedent": {
-      "codename": "820"
+      "codename": "820",
+      "locale": {
+        "fr": "Rongrigou",
+        "de": "Schlaraffel",
+        "ko": "\uc694\uc53d\ub9ac\uc2a4",
+        "ja": "\u30e8\u30af\u30d0\u30ea\u30b9",
+        "zh_CN": "\u85cf\u9971\u6817\u9f20",
+        "zh_TW": "\u85cf\u98fd\u6817\u9f20"
+      }
     },
     "Rookidee": {
-      "codename": "821"
+      "codename": "821",
+      "locale": {
+        "fr": "Minisange",
+        "de": "Meikro",
+        "ko": "\ud30c\ub77c\uaf2c",
+        "ja": "\u30b3\u30b3\u30ac\u30e9",
+        "zh_CN": "\u7a1a\u5c71\u96c0",
+        "zh_TW": "\u7a1a\u5c71\u96c0"
+      }
     },
     "Corvisquire": {
-      "codename": "822"
+      "codename": "822",
+      "locale": {
+        "fr": "Bleuseille",
+        "de": "Kranoviz",
+        "ko": "\ud30c\ud06c\ub85c\uc6b0",
+        "ja": "\u30a2\u30aa\u30ac\u30e9\u30b9",
+        "zh_CN": "\u84dd\u9e26",
+        "zh_TW": "\u85cd\u9d09"
+      }
     },
     "Corviknight": {
-      "codename": "823"
+      "codename": "823",
+      "locale": {
+        "fr": "Corvaillus",
+        "de": "Krarmor",
+        "ko": "\uc544\uba38\uae4c\uc624",
+        "ja": "\u30a2\u30fc\u30de\u30fc\u30ac\u30a2",
+        "zh_CN": "\u94a2\u94e0\u9e26",
+        "zh_TW": "\u92fc\u93a7\u9d09"
+      }
     },
     "Blipbug": {
-      "codename": "824"
+      "codename": "824",
+      "locale": {
+        "fr": "Larvadar",
+        "de": "Sensect",
+        "ko": "\ub450\ub8e8\uc9c0\ubc8c\ub808",
+        "ja": "\u30b5\u30c3\u30c1\u30e0\u30b7",
+        "zh_CN": "\u7d22\u4fa6\u866b",
+        "zh_TW": "\u7d22\u5075\u87f2"
+      }
     },
     "Dottler": {
-      "codename": "825"
+      "codename": "825",
+      "locale": {
+        "fr": "Col\u00e9od\u00f4me",
+        "de": "Keradar",
+        "ko": "\ub808\ub3d4\ubc8c\ub808",
+        "ja": "\u30ec\u30c9\u30fc\u30e0\u30b7",
+        "zh_CN": "\u5929\u7f69\u866b",
+        "zh_TW": "\u5929\u7f69\u87f2"
+      }
     },
     "Orbeetle": {
-      "codename": "826"
+      "codename": "826",
+      "locale": {
+        "fr": "Astronelle",
+        "de": "Maritellit",
+        "ko": "\uc774\uc62c\ube0c",
+        "ja": "\u30a4\u30aa\u30eb\u30d6",
+        "zh_CN": "\u4ee5\u6b27\u8def\u666e",
+        "zh_TW": "\u4ee5\u6b50\u8def\u666e"
+      }
     },
     "Nickit": {
-      "codename": "827"
+      "codename": "827",
+      "locale": {
+        "fr": "Goupilou",
+        "de": "Kleptifux",
+        "ko": "\ud6d4\ucc98\uc6b0",
+        "ja": "\u30af\u30b9\u30cd",
+        "zh_CN": "\u72e1\u5c0f\u72d0",
+        "zh_TW": "\u5077\u5152\u72d0"
+      }
     },
     "Thievul": {
-      "codename": "828"
+      "codename": "828",
+      "locale": {
+        "fr": "Roublenard",
+        "de": "Gaunux",
+        "ko": "\ud3ed\uc2ac\ub77c\uc774",
+        "ja": "\u30d5\u30a9\u30af\u30b9\u30e9\u30a4",
+        "zh_CN": "\u733e\u5927\u72d0",
+        "zh_TW": "\u72d0\u5927\u76dc"
+      }
     },
     "Gossifleur": {
-      "codename": "829"
+      "codename": "829",
+      "locale": {
+        "fr": "Tournicoton",
+        "de": "Cottini",
+        "ko": "\uaf2c\ubaa8\uce74",
+        "ja": "\u30d2\u30e1\u30f3\u30ab",
+        "zh_CN": "\u5e7c\u68c9\u68c9",
+        "zh_TW": "\u5e7c\u68c9\u68c9"
+      }
     },
     "Eldegoss": {
-      "codename": "830"
+      "codename": "830",
+      "locale": {
+        "fr": "Blancoton",
+        "de": "Cottomi",
+        "ko": "\ubc31\uc19c\ubaa8\uce74",
+        "ja": "\u30ef\u30bf\u30b7\u30e9\u30ac",
+        "zh_CN": "\u767d\u84ec\u84ec",
+        "zh_TW": "\u767d\u84ec\u84ec"
+      }
     },
     "Wooloo": {
-      "codename": "831"
+      "codename": "831",
+      "locale": {
+        "fr": "Moumouton",
+        "de": "Wolly",
+        "ko": "\uc6b0\ub974",
+        "ja": "\u30a6\u30fc\u30eb\u30fc",
+        "zh_CN": "\u6bdb\u8fab\u7f8a",
+        "zh_TW": "\u6bdb\u8fae\u7f8a"
+      }
     },
     "Dubwool": {
-      "codename": "832"
+      "codename": "832",
+      "locale": {
+        "fr": "Moumouflon",
+        "de": "Zwollock",
+        "ko": "\ubc30\uc6b0\ub974",
+        "ja": "\u30d0\u30a4\u30a6\u30fc\u30eb\u30fc",
+        "zh_CN": "\u6bdb\u6bdb\u89d2\u7f8a",
+        "zh_TW": "\u6bdb\u6bdb\u89d2\u7f8a"
+      }
     },
     "Chewtle": {
-      "codename": "833"
+      "codename": "833",
+      "locale": {
+        "fr": "Kh\u00e9locrok",
+        "de": "Kamehaps",
+        "ko": "\uae68\ubb3c\ubd80\uae30",
+        "ja": "\u30ab\u30e0\u30ab\u30e1",
+        "zh_CN": "\u54ac\u54ac\u9f9f",
+        "zh_TW": "\u54ac\u54ac\u9f9c"
+      }
     },
     "Drednaw": {
-      "codename": "834"
+      "codename": "834",
+      "locale": {
+        "fr": "Torgamord",
+        "de": "Kamalm",
+        "ko": "\uac08\uac00\ubd80\uae30",
+        "ja": "\u30ab\u30b8\u30ea\u30ac\u30e1",
+        "zh_CN": "\u66b4\u566c\u9f9f",
+        "zh_TW": "\u66b4\u566c\u9f9c"
+      }
     },
     "Yamper": {
-      "codename": "835"
+      "codename": "835",
+      "locale": {
+        "fr": "Voltoutou",
+        "de": "Voldi",
+        "ko": "\uba4d\ud30c\uce58",
+        "ja": "\u30ef\u30f3\u30d1\u30c1",
+        "zh_CN": "\u6765\u7535\u6c6a",
+        "zh_TW": "\u4f86\u96fb\u6c6a"
+      }
     },
     "Boltund": {
-      "codename": "836"
+      "codename": "836",
+      "locale": {
+        "fr": "Fulgudog",
+        "de": "Bellektro",
+        "ko": "\ud384\uc2a4\uba4d",
+        "ja": "\u30d1\u30eb\u30b9\u30ef\u30f3",
+        "zh_CN": "\u9010\u7535\u72ac",
+        "zh_TW": "\u9010\u96fb\u72ac"
+      }
     },
     "Rolycoly": {
-      "codename": "837"
+      "codename": "837",
+      "locale": {
+        "fr": "Charbi",
+        "de": "Klonkett",
+        "ko": "\ud0c4\ub3d9",
+        "ja": "\u30bf\u30f3\u30c9\u30f3",
+        "zh_CN": "\u5c0f\u70ad\u4ed4",
+        "zh_TW": "\u5c0f\u70ad\u4ed4"
+      }
     },
     "Carkol": {
-      "codename": "838"
+      "codename": "838",
+      "locale": {
+        "fr": "Wagomine",
+        "de": "Wagong",
+        "ko": "\ud0c4\ucc28\uace4",
+        "ja": "\u30c8\u30ed\u30c3\u30b4\u30f3",
+        "zh_CN": "\u5927\u70ad\u8f66",
+        "zh_TW": "\u5927\u70ad\u8eca"
+      }
     },
     "Coalossal": {
-      "codename": "839"
+      "codename": "839",
+      "locale": {
+        "fr": "Monthracite",
+        "de": "Montecarbo",
+        "ko": "\uc11d\ud0c4\uc0b0",
+        "ja": "\u30bb\u30ad\u30bf\u30f3\u30b6\u30f3",
+        "zh_CN": "\u5de8\u70ad\u5c71",
+        "zh_TW": "\u5de8\u70ad\u5c71"
+      }
     },
     "Applin": {
-      "codename": "840"
+      "codename": "840",
+      "locale": {
+        "fr": "Verpom",
+        "de": "Knapfel",
+        "ko": "\uacfc\uc0ac\uc0ad\ubc8c\ub808",
+        "ja": "\u30ab\u30b8\u30c3\u30c1\u30e5",
+        "zh_CN": "\u5543\u679c\u866b",
+        "zh_TW": "\u5543\u679c\u87f2"
+      }
     },
     "Flapple": {
-      "codename": "841"
+      "codename": "841",
+      "locale": {
+        "fr": "Pomdrapi",
+        "de": "Drapfel",
+        "ko": "\uc560\ud504\ub8e1",
+        "ja": "\u30a2\u30c3\u30d7\u30ea\u30e5\u30fc",
+        "zh_CN": "\u82f9\u88f9\u9f99",
+        "zh_TW": "\u860b\u88f9\u9f8d"
+      }
     },
     "Appletun": {
-      "codename": "842"
+      "codename": "842",
+      "locale": {
+        "fr": "Dratatin",
+        "de": "Schlapfel",
+        "ko": "\ub2e8\uc9c0\ub798\ud50c",
+        "ja": "\u30bf\u30eb\u30c3\u30d7\u30eb",
+        "zh_CN": "\u4e30\u871c\u9f99",
+        "zh_TW": "\u8c50\u871c\u9f8d"
+      }
     },
     "Silicobra": {
-      "codename": "843"
+      "codename": "843",
+      "locale": {
+        "fr": "Dunaja",
+        "de": "Salanga",
+        "ko": "\ubaa8\ub798\ubc40",
+        "ja": "\u30b9\u30ca\u30d8\u30d3",
+        "zh_CN": "\u6c99\u5305\u86c7",
+        "zh_TW": "\u6c99\u5305\u86c7"
+      }
     },
     "Sandaconda": {
-      "codename": "844"
+      "codename": "844",
+      "locale": {
+        "fr": "Dunaconda",
+        "de": "Sanaconda",
+        "ko": "\uc0ac\ub2e4\uc774\uc0ac",
+        "ja": "\u30b5\u30c0\u30a4\u30b8\u30e3",
+        "zh_CN": "\u6c99\u87ba\u87d2",
+        "zh_TW": "\u6c99\u87ba\u87d2"
+      }
     },
     "Cramorant": {
-      "codename": "845"
+      "codename": "845",
+      "locale": {
+        "fr": "Nigosier",
+        "de": "Urgl",
+        "ko": "\uc73d\uc6b0\uc9c0",
+        "ja": "\u30a6\u30c3\u30a6",
+        "zh_CN": "\u53e4\u6708\u9e1f",
+        "zh_TW": "\u53e4\u6708\u9ce5"
+      }
     },
     "Arrokuda": {
-      "codename": "846"
+      "codename": "846",
+      "locale": {
+        "fr": "Embrochet",
+        "de": "Pikuda",
+        "ko": "\ucc0c\ub85c\uaf2c\uce58",
+        "ja": "\u30b5\u30b7\u30ab\u30de\u30b9",
+        "zh_CN": "\u523a\u68ad\u9c7c",
+        "zh_TW": "\u523a\u68ad\u9b5a"
+      }
     },
     "Barraskewda": {
-      "codename": "847"
+      "codename": "847",
+      "locale": {
+        "fr": "Hastacuda",
+        "de": "Barrakiefa",
+        "ko": "\uaf2c\uce58\uc870",
+        "ja": "\u30ab\u30de\u30b9\u30b8\u30e7\u30fc",
+        "zh_CN": "\u623d\u6597\u5c16\u68ad",
+        "zh_TW": "\u623d\u6597\u5c16\u68ad"
+      }
     },
     "Toxel": {
-      "codename": "848"
+      "codename": "848",
+      "locale": {
+        "fr": "Toxizap",
+        "de": "Toxel",
+        "ko": "\uc77c\ub808\uc98c",
+        "ja": "\u30a8\u30ec\u30ba\u30f3",
+        "zh_CN": "\u7535\u97f3\u5a74",
+        "zh_TW": "\u6bd2\u96fb\u5b30"
+      }
     },
     "Toxtricity": {
-      "codename": "849"
+      "codename": "849",
+      "locale": {
+        "fr": "Salarsen",
+        "de": "Riffex",
+        "ko": "\uc2a4\ud2b8\ub9b0\ub354",
+        "ja": "\u30b9\u30c8\u30ea\u30f3\u30c0\u30fc",
+        "zh_CN": "\u98a4\u5f26\u877e\u8788",
+        "zh_TW": "\u986b\u5f26\u8811\u8788"
+      }
     },
     "Sizzlipede": {
-      "codename": "850"
+      "codename": "850",
+      "locale": {
+        "fr": "Grillepattes",
+        "de": "Thermopod",
+        "ko": "\ud0dc\uc6b0\uc9c0\ub124",
+        "ja": "\u30e4\u30af\u30c7",
+        "zh_CN": "\u70e7\u706b\u86a3",
+        "zh_TW": "\u71d2\u706b\u86a3"
+      }
     },
     "Centiskorch": {
-      "codename": "851"
+      "codename": "851",
+      "locale": {
+        "fr": "Scolocendre",
+        "de": "Infernopod",
+        "ko": "\ub2e4\ud0dc\uc6b0\uc9c0\ub124",
+        "ja": "\u30de\u30eb\u30e4\u30af\u30c7",
+        "zh_CN": "\u711a\u7130\u86a3",
+        "zh_TW": "\u711a\u7130\u86a3"
+      }
     },
     "Clobbopus": {
-      "codename": "852"
+      "codename": "852",
+      "locale": {
+        "fr": "Poulpaf",
+        "de": "Klopptopus",
+        "ko": "\ub54c\ub54c\ubb34\ub178",
+        "ja": "\u30bf\u30bf\u30c3\u30b3",
+        "zh_CN": "\u62f3\u62f3\u86f8",
+        "zh_TW": "\u62f3\u62f3\u86f8"
+      }
     },
     "Grapploct": {
-      "codename": "853"
+      "codename": "853",
+      "locale": {
+        "fr": "Krakos",
+        "de": "Kaocto",
+        "ko": "\ucf00\uc624\ud37c\uc2a4",
+        "ja": "\u30aa\u30c8\u30b9\u30d1\u30b9",
+        "zh_CN": "\u516b\u722a\u6b66\u5e08",
+        "zh_TW": "\u516b\u722a\u6b66\u5e2b"
+      }
     },
     "Sinistea": {
-      "codename": "854"
+      "codename": "854",
+      "locale": {
+        "fr": "Th\u00e9ffroi",
+        "de": "Fatalitee",
+        "ko": "\ub370\uc778\ucc28",
+        "ja": "\u30e4\u30d0\u30c1\u30e3",
+        "zh_CN": "\u6765\u60b2\u8336",
+        "zh_TW": "\u4f86\u60b2\u8336"
+      }
     },
     "Polteageist": {
-      "codename": "855"
+      "codename": "855",
+      "locale": {
+        "fr": "Polth\u00e9geist",
+        "de": "Mortipot",
+        "ko": "\ud3ec\ud2b8\ub370\uc2a4",
+        "ja": "\u30dd\u30c3\u30c8\u30c7\u30b9",
+        "zh_CN": "\u6016\u601d\u58f6",
+        "zh_TW": "\u6016\u601d\u58fa"
+      }
     },
     "Hatenna": {
-      "codename": "856"
+      "codename": "856",
+      "locale": {
+        "fr": "Bibichut",
+        "de": "Brimova",
+        "ko": "\ubab8\uc9c0\ube0c\ub9bc",
+        "ja": "\u30df\u30d6\u30ea\u30e0",
+        "zh_CN": "\u8ff7\u5e03\u8389\u59c6",
+        "zh_TW": "\u8ff7\u5e03\u8389\u59c6"
+      }
     },
     "Hattrem": {
-      "codename": "857"
+      "codename": "857",
+      "locale": {
+        "fr": "Chapotus",
+        "de": "Brimano",
+        "ko": "\uc190\uc9c0\ube0c\ub9bc",
+        "ja": "\u30c6\u30d6\u30ea\u30e0",
+        "zh_CN": "\u63d0\u5e03\u8389\u59c6",
+        "zh_TW": "\u63d0\u5e03\u8389\u59c6"
+      }
     },
     "Hatterene": {
-      "codename": "858"
+      "codename": "858",
+      "locale": {
+        "fr": "Sorcilence",
+        "de": "Silembrim",
+        "ko": "\ube0c\ub9ac\ubb34\uc74c",
+        "ja": "\u30d6\u30ea\u30e0\u30aa\u30f3",
+        "zh_CN": "\u5e03\u8389\u59c6\u6e29",
+        "zh_TW": "\u5e03\u8389\u59c6\u6eab"
+      }
     },
     "Impidimp": {
-      "codename": "859"
+      "codename": "859",
+      "locale": {
+        "fr": "Grimalin",
+        "de": "B\u00e4hmon",
+        "ko": "\uba54\ub871\uafcd",
+        "ja": "\u30d9\u30ed\u30d0\u30fc",
+        "zh_CN": "\u6363\u86cb\u5c0f\u5996",
+        "zh_TW": "\u6417\u86cb\u5c0f\u5996"
+      }
     },
     "Morgrem": {
-      "codename": "860"
+      "codename": "860",
+      "locale": {
+        "fr": "Fourbelin",
+        "de": "Pelzebub",
+        "ko": "\uc3d8\uaca8\ubaa8",
+        "ja": "\u30ae\u30e2\u30fc",
+        "zh_CN": "\u8bc8\u552c\u9b54",
+        "zh_TW": "\u8a50\u552c\u9b54"
+      }
     },
     "Grimmsnarl": {
-      "codename": "861"
+      "codename": "861",
+      "locale": {
+        "fr": "Angoliath",
+        "de": "Olangaar",
+        "ko": "\uc624\ub871\ud138",
+        "ja": "\u30aa\u30fc\u30ed\u30f3\u30b2",
+        "zh_CN": "\u957f\u6bdb\u5de8\u9b54",
+        "zh_TW": "\u9577\u6bdb\u5de8\u9b54"
+      }
     },
     "Obstagoon": {
-      "codename": "862"
+      "codename": "862",
+      "locale": {
+        "fr": "Ixon",
+        "de": "Barrikadax",
+        "ko": "\uac00\ub85c\ub9c9\uad6c\ub9ac",
+        "ja": "\u30bf\u30c1\u30d5\u30b5\u30b0\u30de",
+        "zh_CN": "\u5835\u62e6\u718a",
+        "zh_TW": "\u5835\u6514\u718a"
+      }
     },
     "Perrserker": {
-      "codename": "863"
+      "codename": "863",
+      "locale": {
+        "fr": "Berserkatt",
+        "de": "Mauzinger",
+        "ko": "\ub098\uc774\ud0b9",
+        "ja": "\u30cb\u30e3\u30a4\u30ad\u30f3\u30b0",
+        "zh_CN": "\u55b5\u5934\u76ee",
+        "zh_TW": "\u55b5\u982d\u76ee"
+      }
     },
     "Cursola": {
-      "codename": "864"
+      "codename": "864",
+      "locale": {
+        "fr": "Coray\u00f4me",
+        "de": "Gorgasonn",
+        "ko": "\uc0b0\ud638\ub974\uace4",
+        "ja": "\u30b5\u30cb\u30b4\u30fc\u30f3",
+        "zh_CN": "\u9b54\u7075\u73ca\u745a",
+        "zh_TW": "\u9b54\u9748\u73ca\u745a"
+      }
     },
     "Sirfetch'd": {
-      "codename": "865"
+      "codename": "865",
+      "locale": {
+        "fr": "Palarticho",
+        "de": "Lauchzelot",
+        "ko": "\ucc3d\ud30c\ub098\uc774\ud2b8",
+        "ja": "\u30cd\u30ae\u30ac\u30ca\u30a4\u30c8",
+        "zh_CN": "\u8471\u6e38\u5175",
+        "zh_TW": "\u8525\u904a\u5175"
+      }
     },
     "Mr. Rime": {
-      "codename": "866"
+      "codename": "866",
+      "locale": {
+        "fr": "M. Glaquette",
+        "de": "Pantifrost",
+        "ko": "\ub9c8\uc784\uaf41\uaf41",
+        "ja": "\u30d0\u30ea\u30b3\u30aa\u30eb",
+        "zh_CN": "\u8e0f\u51b0\u4eba\u5076",
+        "zh_TW": "\u8e0f\u51b0\u4eba\u5076"
+      }
     },
     "Runerigus": {
-      "codename": "867"
+      "codename": "867",
+      "locale": {
+        "fr": "Tut\u00e9t\u00e9kri",
+        "de": "Oghnatoll",
+        "ko": "\ub370\uc2a4\ud310",
+        "ja": "\u30c7\u30b9\u30d0\u30fc\u30f3",
+        "zh_CN": "\u8fed\u5931\u677f",
+        "zh_TW": "\u6b7b\u795e\u677f"
+      }
     },
     "Milcery": {
-      "codename": "868"
+      "codename": "868",
+      "locale": {
+        "fr": "Cr\u00e8my",
+        "de": "Hokumil",
+        "ko": "\ub9c8\ube4c\ud06c",
+        "ja": "\u30de\u30db\u30df\u30eb",
+        "zh_CN": "\u5c0f\u4ed9\u5976",
+        "zh_TW": "\u5c0f\u4ed9\u5976"
+      }
     },
     "Alcremie": {
-      "codename": "869"
+      "codename": "869",
+      "locale": {
+        "fr": "Charmilly",
+        "de": "Pokusan",
+        "ko": "\ub9c8\ud718\ud551",
+        "ja": "\u30de\u30db\u30a4\u30c3\u30d7",
+        "zh_CN": "\u971c\u5976\u4ed9",
+        "zh_TW": "\u971c\u5976\u4ed9"
+      }
     },
     "Falinks": {
-      "codename": "870"
+      "codename": "870",
+      "locale": {
+        "fr": "Hexadron",
+        "de": "Legios",
+        "ko": "\ub300\uc5ec\ub974",
+        "ja": "\u30bf\u30a4\u30ec\u30fc\u30c4",
+        "zh_CN": "\u5217\u9635\u5175",
+        "zh_TW": "\u5217\u9663\u5175"
+      }
     },
     "Pincurchin": {
-      "codename": "871"
+      "codename": "871",
+      "locale": {
+        "fr": "Wattapik",
+        "de": "Britzigel",
+        "ko": "\ucc0c\ub974\uc131\uac8c",
+        "ja": "\u30d0\u30c1\u30f3\u30a6\u30cb",
+        "zh_CN": "\u556a\u5693\u6d77\u80c6",
+        "zh_TW": "\u556a\u5693\u6d77\u81bd"
+      }
     },
     "Snom": {
-      "codename": "872"
+      "codename": "872",
+      "locale": {
+        "fr": "Frissonille",
+        "de": "Snomnom",
+        "ko": "\ub204\ub2c8\uba38\uae30",
+        "ja": "\u30e6\u30ad\u30cf\u30df",
+        "zh_CN": "\u96ea\u541e\u866b",
+        "zh_TW": "\u96ea\u541e\u87f2"
+      }
     },
     "Frosmoth": {
-      "codename": "873"
+      "codename": "873",
+      "locale": {
+        "fr": "Beldeneige",
+        "de": "Mottineva",
+        "ko": "\ubaa8\uc2a4\ub178\uc6b0",
+        "ja": "\u30e2\u30b9\u30ce\u30a6",
+        "zh_CN": "\u96ea\u7ed2\u86fe",
+        "zh_TW": "\u96ea\u7d68\u86fe"
+      }
     },
     "Stonjourner": {
-      "codename": "874"
+      "codename": "874",
+      "locale": {
+        "fr": "Dolman",
+        "de": "Humanolith",
+        "ko": "\ub3cc\ud5e8\uc9c4",
+        "ja": "\u30a4\u30b7\u30d8\u30f3\u30b8\u30f3",
+        "zh_CN": "\u5de8\u77f3\u4e01",
+        "zh_TW": "\u5de8\u77f3\u4e01"
+      }
     },
     "Eiscue": {
-      "codename": "875"
+      "codename": "875",
+      "locale": {
+        "fr": "Bekagla\u00e7on",
+        "de": "Kubuin",
+        "ko": "\ube59\ud050\ubcf4",
+        "ja": "\u30b3\u30aa\u30ea\u30c3\u30dd",
+        "zh_CN": "\u51b0\u780c\u9e45",
+        "zh_TW": "\u51b0\u780c\u9d5d"
+      }
     },
     "Indeedee": {
-      "codename": "876"
+      "codename": "876",
+      "locale": {
+        "fr": "Wimessir",
+        "de": "Servol",
+        "ko": "\uc5d0\uc368\ub974",
+        "ja": "\u30a4\u30a8\u30c3\u30b5\u30f3",
+        "zh_CN": "\u7231\u7ba1\u4f8d",
+        "zh_TW": "\u611b\u7ba1\u4f8d"
+      }
     },
     "Morpeko": {
-      "codename": "877"
+      "codename": "877",
+      "locale": {
+        "fr": "Morpeko",
+        "de": "Morpeko",
+        "ko": "\ubaa8\ub974\ud398\ucf54",
+        "ja": "\u30e2\u30eb\u30da\u30b3",
+        "zh_CN": "\u83ab\u9c81\u8d1d\u53ef",
+        "zh_TW": "\u83ab\u9b6f\u8c9d\u53ef"
+      }
     },
     "Cufant": {
-      "codename": "878"
+      "codename": "878",
+      "locale": {
+        "fr": "Charibari",
+        "de": "Kupfanti",
+        "ko": "\ub07c\ub9ac\ub3d9",
+        "ja": "\u30be\u30a6\u30c9\u30a6",
+        "zh_CN": "\u94dc\u8c61",
+        "zh_TW": "\u9285\u8c61"
+      }
     },
     "Copperajah": {
-      "codename": "879"
+      "codename": "879",
+      "locale": {
+        "fr": "Pachyradjah",
+        "de": "Patinaraja",
+        "ko": "\ub300\uc655\ub07c\ub9ac\ub3d9",
+        "ja": "\u30c0\u30a4\u30aa\u30a6\u30c9\u30a6",
+        "zh_CN": "\u5927\u738b\u94dc\u8c61",
+        "zh_TW": "\u5927\u738b\u9285\u8c61"
+      }
     },
     "Dracozolt": {
-      "codename": "880"
+      "codename": "880",
+      "locale": {
+        "fr": "Galvagon",
+        "de": "Lectragon",
+        "ko": "\ud30c\uce58\ub798\uace4",
+        "ja": "\u30d1\u30c3\u30c1\u30e9\u30b4\u30f3",
+        "zh_CN": "\u96f7\u9e1f\u9f99",
+        "zh_TW": "\u96f7\u9ce5\u9f8d"
+      }
     },
     "Arctozolt": {
-      "codename": "881"
+      "codename": "881",
+      "locale": {
+        "fr": "Galvagla",
+        "de": "Lecryodon",
+        "ko": "\ud30c\uce58\ub974\ub3c8",
+        "ja": "\u30d1\u30c3\u30c1\u30eb\u30c9\u30f3",
+        "zh_CN": "\u96f7\u9e1f\u6d77\u517d",
+        "zh_TW": "\u96f7\u9ce5\u6d77\u7378"
+      }
     },
     "Dracovish": {
-      "codename": "882"
+      "codename": "882",
+      "locale": {
+        "fr": "Hydragon",
+        "de": "Pescragon",
+        "ko": "\uc5b4\ub798\uace4",
+        "ja": "\u30a6\u30aa\u30ce\u30e9\u30b4\u30f3",
+        "zh_CN": "\u9cc3\u9c7c\u9f99",
+        "zh_TW": "\u9c13\u9b5a\u9f8d"
+      }
     },
     "Arctovish": {
-      "codename": "883"
+      "codename": "883",
+      "locale": {
+        "fr": "Hydragla",
+        "de": "Pescryodon",
+        "ko": "\uc5b4\uce58\ub974\ub3c8",
+        "ja": "\u30a6\u30aa\u30c1\u30eb\u30c9\u30f3",
+        "zh_CN": "\u9cc3\u9c7c\u6d77\u517d",
+        "zh_TW": "\u9c13\u9b5a\u6d77\u7378"
+      }
     },
     "Duraludon": {
-      "codename": "884"
+      "codename": "884",
+      "locale": {
+        "fr": "Duralugon",
+        "de": "Duraludon",
+        "ko": "\ub450\ub784\ub8e8\ub3c8",
+        "ja": "\u30b8\u30e5\u30e9\u30eb\u30c9\u30f3",
+        "zh_CN": "\u94dd\u94a2\u9f99",
+        "zh_TW": "\u92c1\u92fc\u9f8d"
+      }
     },
     "Dreepy": {
-      "codename": "885"
+      "codename": "885",
+      "locale": {
+        "fr": "Fantyrm",
+        "de": "Grolldra",
+        "ko": "\ub4dc\ub77c\uaf30",
+        "ja": "\u30c9\u30e9\u30e1\u30b7\u30e4",
+        "zh_CN": "\u591a\u9f99\u6885\u897f\u4e9a",
+        "zh_TW": "\u591a\u9f8d\u6885\u897f\u4e9e"
+      }
     },
     "Drakloak": {
-      "codename": "886"
+      "codename": "886",
+      "locale": {
+        "fr": "Dispareptil",
+        "de": "Phandra",
+        "ko": "\ub4dc\ub798\ub7f0\uce58",
+        "ja": "\u30c9\u30ed\u30f3\u30c1",
+        "zh_CN": "\u591a\u9f99\u5947",
+        "zh_TW": "\u591a\u9f8d\u5947"
+      }
     },
     "Dragapult": {
-      "codename": "887"
+      "codename": "887",
+      "locale": {
+        "fr": "Lanssorien",
+        "de": "Katapuldra",
+        "ko": "\ub4dc\ub798\ud384\ud2b8",
+        "ja": "\u30c9\u30e9\u30d1\u30eb\u30c8",
+        "zh_CN": "\u591a\u9f99\u5df4\u9c81\u6258",
+        "zh_TW": "\u591a\u9f8d\u5df4\u9b6f\u6258"
+      }
     },
     "Zacian": {
-      "codename": "888"
+      "codename": "888",
+      "locale": {
+        "fr": "Zacian",
+        "de": "Zacian",
+        "ko": "\uc790\uc2dc\uc548",
+        "ja": "\u30b6\u30b7\u30a2\u30f3",
+        "zh_CN": "\u82cd\u54cd",
+        "zh_TW": "\u84bc\u97ff"
+      }
     },
     "Zamazenta": {
-      "codename": "889"
+      "codename": "889",
+      "locale": {
+        "fr": "Zamazenta",
+        "de": "Zamazenta",
+        "ko": "\uc790\ub9c8\uc820\ud0c0",
+        "ja": "\u30b6\u30de\u30bc\u30f3\u30bf",
+        "zh_CN": "\u85cf\u739b\u7136\u7279",
+        "zh_TW": "\u85cf\u746a\u7136\u7279"
+      }
     },
     "Eternatus": {
-      "codename": "890"
+      "codename": "890",
+      "locale": {
+        "fr": "\u00c9thernatos",
+        "de": "Endynalos",
+        "ko": "\ubb34\ud55c\ub2e4\uc774\ub178",
+        "ja": "\u30e0\u30b2\u30f3\u30c0\u30a4\u30ca",
+        "zh_CN": "\u65e0\u6781\u6c70\u90a3",
+        "zh_TW": "\u7121\u6975\u6c70\u90a3"
+      }
     },
     "Kubfu": {
-      "codename": "891"
+      "codename": "891",
+      "locale": {
+        "fr": "Wushours",
+        "de": "Dakuma",
+        "ko": "\uce58\uace0\ub9c8",
+        "ja": "\u30c0\u30af\u30de",
+        "zh_CN": "\u718a\u5f92\u5f1f",
+        "zh_TW": "\u718a\u5f92\u5f1f"
+      }
     },
     "Urshifu": {
-      "codename": "892"
+      "codename": "892",
+      "locale": {
+        "fr": "Shifours",
+        "de": "Wulaosu",
+        "ko": "\uc6b0\ub77c\uc624\uc2a4",
+        "ja": "\u30a6\u30fc\u30e9\u30aa\u30b9",
+        "zh_CN": "\u6b66\u9053\u718a\u5e08",
+        "zh_TW": "\u6b66\u9053\u718a\u5e2b"
+      }
     },
     "Zarude": {
-      "codename": "893"
+      "codename": "893",
+      "locale": {
+        "fr": "Zarude",
+        "de": "Zarude",
+        "ko": "\uc790\ub8e8\ub3c4",
+        "ja": "\u30b6\u30eb\u30fc\u30c9",
+        "zh_CN": "\u8428\u622e\u5fb7",
+        "zh_TW": "\u85a9\u622e\u5fb7"
+      }
     },
     "Regieleki": {
-      "codename": "894"
+      "codename": "894",
+      "locale": {
+        "fr": "Regieleki",
+        "de": "Regieleki",
+        "ko": "\ub808\uc9c0\uc5d0\ub808\ud0a4",
+        "ja": "\u30ec\u30b8\u30a8\u30ec\u30ad",
+        "zh_CN": "\u96f7\u5409\u827e\u52d2\u5947",
+        "zh_TW": "\u96f7\u5409\u827e\u52d2\u5947"
+      }
     },
     "Regidrago": {
-      "codename": "895"
+      "codename": "895",
+      "locale": {
+        "fr": "Regidrago",
+        "de": "Regidrago",
+        "ko": "\ub808\uc9c0\ub4dc\ub798\uace0",
+        "ja": "\u30ec\u30b8\u30c9\u30e9\u30b4",
+        "zh_CN": "\u96f7\u5409\u94ce\u62c9\u6208",
+        "zh_TW": "\u96f7\u5409\u9438\u62c9\u6208"
+      }
     },
     "Glastrier": {
-      "codename": "896"
+      "codename": "896",
+      "locale": {
+        "fr": "Blizzeval",
+        "de": "Polaross",
+        "ko": "\ube14\ub9ac\uc790\ud3ec\uc2a4",
+        "ja": "\u30d6\u30ea\u30b6\u30dd\u30b9",
+        "zh_CN": "\u96ea\u66b4\u9a6c",
+        "zh_TW": "\u96ea\u66b4\u99ac"
+      }
     },
     "Spectrier": {
-      "codename": "897"
+      "codename": "897",
+      "locale": {
+        "fr": "Spectreval",
+        "de": "Phantoross",
+        "ko": "\ub808\uc774\uc2a4\ud3ec\uc2a4",
+        "ja": "\u30ec\u30a4\u30b9\u30dd\u30b9",
+        "zh_CN": "\u7075\u5e7d\u9a6c",
+        "zh_TW": "\u9748\u5e7d\u99ac"
+      }
     },
     "Calyrex": {
-      "codename": "898"
+      "codename": "898",
+      "locale": {
+        "fr": "Sylveroy",
+        "de": "Coronospa",
+        "ko": "\ubc84\ub4dc\ub809\uc2a4",
+        "ja": "\u30d0\u30c9\u30ec\u30c3\u30af\u30b9",
+        "zh_CN": "\u857e\u51a0\u738b",
+        "zh_TW": "\u857e\u51a0\u738b"
+      }
     },
     "Wyrdeer": {
-      "codename": "899"
+      "codename": "899",
+      "locale": {
+        "fr": "Cerbyllin",
+        "de": "Damythir",
+        "ko": "\uc2e0\ube44\ub85d",
+        "ja": "\u30a2\u30e4\u30b7\u30b7",
+        "zh_CN": "\u8be1\u89d2\u9e7f",
+        "zh_TW": "\u8a6d\u89d2\u9e7f"
+      }
     },
     "Kleavor": {
-      "codename": "900"
+      "codename": "900",
+      "locale": {
+        "fr": "Hach\u00e9cateur",
+        "de": "Axantor",
+        "ko": "\uc0ac\ub9c8\uc790\ub974",
+        "ja": "\u30d0\u30b5\u30ae\u30ea",
+        "zh_CN": "\u5288\u65a7\u87b3\u8782",
+        "zh_TW": "\u5288\u65a7\u87b3\u8782"
+      }
     },
     "Ursaluna": {
-      "codename": "901"
+      "codename": "901",
+      "locale": {
+        "fr": "Ursaking",
+        "de": "Ursaluna",
+        "ko": "\ub2e4\ud22c\uacf0",
+        "ja": "\u30ac\u30c1\u30b0\u30de",
+        "zh_CN": "\u6708\u6708\u718a",
+        "zh_TW": "\u6708\u6708\u718a"
+      }
     },
     "Basculegion": {
-      "codename": "902"
+      "codename": "902",
+      "locale": {
+        "fr": "Paragruel",
+        "de": "Salmagnis",
+        "ko": "\ub300\uc4f0\uc5ec\ub108",
+        "ja": "\u30a4\u30c0\u30a4\u30c8\u30a6",
+        "zh_CN": "\u5e7d\u5c3e\u7384\u9c7c",
+        "zh_TW": "\u5e7d\u5c3e\u7384\u9b5a"
+      }
     },
     "Sneasler": {
-      "codename": "903"
+      "codename": "903",
+      "locale": {
+        "fr": "Farfurex",
+        "de": "Snieboss",
+        "ko": "\ud3ec\ud478\ub2c8\ud06c",
+        "ja": "\u30aa\u30aa\u30cb\u30e5\u30fc\u30e9",
+        "zh_CN": "\u5927\u72c3\u62c9",
+        "zh_TW": "\u5927\u72c3\u62c9"
+      }
     },
     "Overqwil": {
-      "codename": "904"
+      "codename": "904",
+      "locale": {
+        "fr": "Qwilpik",
+        "de": "Myriador",
+        "ko": "\uc7a5\uce68\ubc14\ub8e8",
+        "ja": "\u30cf\u30ea\u30fc\u30de\u30f3",
+        "zh_CN": "\u4e07\u9488\u9c7c",
+        "zh_TW": "\u842c\u91dd\u9b5a"
+      }
     },
     "Enamorus": {
-      "codename": "905"
+      "codename": "905",
+      "locale": {
+        "fr": "Amov\u00e9nus",
+        "de": "Cupidos",
+        "ko": "\ub7ec\ube0c\ub85c\uc2a4",
+        "ja": "\u30e9\u30d6\u30c8\u30ed\u30b9",
+        "zh_CN": "\u7737\u604b\u4e91",
+        "zh_TW": "\u7737\u6200\u96f2"
+      }
     }
   },
   "stage_to_codename": {},
-  "version": "1.15",
+  "version": "1.16",
   "description": "Base config to use this game.",
-  "credits": "Arclart for the Pokémon Legends: Arceus icons",
+  "credits": "Arclart for the Pok\u00e9mon Legends: Arceus icons",
   "challonge_game_id": 159142
 }

--- a/games/pocket/base_files/config.json
+++ b/games/pocket/base_files/config.json
@@ -1,7 +1,7 @@
 {
   "challonge_game_id": null,
   "locale": {
-    "jp": "ポケットファイター"
+    "ja": {"name":"ポケットファイター"}
   },
   "character_to_codename": {
     "Akuma": {
@@ -46,5 +46,5 @@
   "name": "Super Gem Fighter: Mini Mix",
   "smashgg_game_id": 16124,
   "stage_to_codename": {},
-  "version": "1.0"
+  "version": "1.01"
 }

--- a/games/sms/base_files/config.json
+++ b/games/sms/base_files/config.json
@@ -34,5 +34,22 @@
   "stage_to_codename": {},
   "version": "1.01",
   "description": "Base config to use this game.",
-  "credits": ""
+  "credits": "",
+  "locale": {
+    "fr_FR": {
+      "name": "Mario Smash Football"
+    },
+    "it": {
+      "name": "Mario Smash Football"
+    },
+    "de": {
+      "name": "Mario Smash Football"
+    },
+    "nl": {
+      "name": "Mario Smash Football"
+    },
+    "es_ES": {
+      "name": "Mario Smash Football"
+    }
+  }
 }

--- a/games/snesmoon/base_files/config.json
+++ b/games/snesmoon/base_files/config.json
@@ -33,7 +33,7 @@
   "description": "Base config to use this game.",
   "name": "Bishoujo Senshi Sailor Moon S: Jougai Rantou!? Shuyaku Soudatsusen",
   "locale": {
-    "jp": "美少女戦士セーラームーンS: 場外乱闘！？主役争奪戦"
+    "ja": {"name":"美少女戦士セーラームーンS: 場外乱闘！？主役争奪戦"}
   },
   "smashgg_game_id": 16904,
   "stage_to_codename": {},

--- a/games/windjammers/base_files/config.json
+++ b/games/windjammers/base_files/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Windjammers",
   "locale": {
-    "jp": "フライングパワーディスク: Windjammers"
+    "ja": {"name":"フライングパワーディスク: Windjammers"}
   },
   "smashgg_game_id": 33,
   "challonge_game_id": 719,
@@ -32,7 +32,7 @@
     }
   },
   "stage_to_codename": {},
-  "version": "1.12",
+  "version": "1.13",
   "description": "Base config to use this game.",
   "credits": "Assets ripped from Mizuumi Wiki (https://wiki.gbl.gg/w/Windjammers)"
 }

--- a/utilities/translate_pokemon_names/translate_pokemon_names.py
+++ b/utilities/translate_pokemon_names/translate_pokemon_names.py
@@ -1,0 +1,36 @@
+import requests
+import json
+from copy import deepcopy
+
+link_to_names = "https://raw.githubusercontent.com/sindresorhus/pokemon/main/data/[lang].json"
+lang_list = ["fr", "de", "ko", "ja", "zh-hans", "zh-hant"]
+config_file_path = "../../games/pkmn/base_files/config.json"
+
+with open(config_file_path, 'rt', encoding='utf-8') as config_file:
+    config_contents_text = config_file.read()
+    config_contents = json.loads(config_contents_text)
+
+list_pokemon_by_lang = {}
+for current_locale in lang_list:
+    actual_locale = deepcopy(current_locale)
+    if current_locale == "zh-hans":
+        actual_locale = "zh_CN"
+    if current_locale == "zh-hant":
+        actual_locale = "zh_TW"
+    response = requests.get(link_to_names.replace("[lang]", current_locale))
+    list_of_pokemon = json.loads(response.text)
+    list_pokemon_by_lang[actual_locale] = deepcopy(list_of_pokemon)
+    
+codenames_dict = config_contents.get("character_to_codename")
+for character in codenames_dict.keys():
+    print(character)
+    codename = codenames_dict.get(character).get("codename")
+    index = int(codename)-1
+    if not codenames_dict.get(character).get("locale"):
+        config_contents["character_to_codename"][character]["locale"] = {}
+    for current_locale in list_pokemon_by_lang.keys():
+        config_contents["character_to_codename"][character]["locale"][current_locale] = list_pokemon_by_lang[current_locale][index]
+
+with open(config_file_path, 'wt', encoding='utf-8') as config_file:
+    config_contents_text = json.dumps(config_contents, indent=2)
+    config_file.write(config_contents_text)


### PR DESCRIPTION
- Added locale data for Pokémon
  - Includes all official in-game translations for: French, German, Japanese, Korean, Simplified Chinese, Traditional Chinese
    - Remainder: All Pokémon names are identical to English in Spanish and Italian
- Added data structure for description/credits translation
  - Changed data structure for title translation
- Fixed `ja` locale entered as `jp`