### PR TITLE
SPL3: Added extra metadata for Subs and Specials

### DIFF
--- a/games/spl3/special/config.json
+++ b/games/spl3/special/config.json
@@ -8,8 +8,8 @@
     "special"
   ],
   "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
-  "extra_data": [
-    {
+  "extra_data": {
+    "spe_name": {
       "title": "Special weapon",
       "locale": {
         "fr": "Arme sp\u00e9ciale"
@@ -848,11 +848,11 @@
         }
       }
     }
-  ],
+  },
   "uncropped_edge": [
-      "u",
-      "d",
-      "l",
-      "r"
+    "u",
+    "d",
+    "l",
+    "r"
   ]
 }

--- a/games/spl3/special/config.json
+++ b/games/spl3/special/config.json
@@ -8,7 +8,7 @@
     "special"
   ],
   "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
-  "extra_data": {
+  "metadata": {
     "spe_name": {
       "title": "Special weapon",
       "locale": {

--- a/games/spl3/special/config.json
+++ b/games/spl3/special/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Special Icons",
-  "version": "1.1",
+  "version": "1.11",
   "description": "Special icons",
   "prefix": "spe_",
   "postfix": "_",
@@ -8,6 +8,847 @@
     "special"
   ],
   "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
+  "extra_data": [
+    {
+      "title": "Special weapon",
+      "locale": {
+        "fr": "Arme sp\u00e9ciale"
+      },
+      "values": {
+        "52Gal": {
+          "value": "Killer Wail 5.1",
+          "locale": {
+            "ja": "\u30e1\u30ac\u30db\u30f3\u30ec\u30fc\u30b6\u30fc5.1ch",
+            "ko": "\uba54\uac00\ud3f0 \ub808\uc774\uc800 5.1ch",
+            "zh_TW": "\u5587\u53ed\u96f7\u5c045.1ch",
+            "zh_CN": "\u5587\u53ed\u956d\u5c045.1ch",
+            "ru": "\u041c\u0435\u0433\u0430\u043b\u043e\u0444\u043e\u043d 5.1",
+            "nl": "Megalofoon 5.1",
+            "de": "Heulboje 5.1",
+            "it": "Tintofono 5.1",
+            "fr_CA": "Laser per\u00e7ant 5.1",
+            "es": "Tint\u00f3fono 5.1",
+            "es_LA": "Berre\u00f3n 5.1",
+            "fr": "Haut-perceur 5.1"
+          }
+        },
+        "96Gal": {
+          "value": "Ink Vac",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30a4\u30f3\u30ad",
+            "ko": "\ud761\uc785\uae30",
+            "zh_TW": "\u5438\u58a8\u6a5f",
+            "zh_CN": "\u5438\u58a8\u673a",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0441\u043e\u0441",
+            "fr": "Aspirencre",
+            "nl": "Inktdief",
+            "de": "Tintegrator",
+            "it": "Vampinchiostro",
+            "es": "Aspiratinta"
+          }
+        },
+        "AerosprayMG": {
+          "value": "Reefslider",
+          "locale": {
+            "ja": "\u30b5\u30e1\u30e9\u30a4\u30c9",
+            "ko": "\uc0e4\ud06c \ub77c\uc774\ub4dc",
+            "zh_TW": "\u9bca\u9b5a\u5750\u9a0e",
+            "zh_CN": "\u9ca8\u9c7c\u5750\u9a91",
+            "ru": "\u041c\u043e\u0442\u043e\u043a\u0443\u043b\u0430",
+            "fr": "Cavalsquale",
+            "nl": "Opblaashaai",
+            "de": "Haihammer",
+            "it": "Motosqualo",
+            "es": "Flotibur\u00f3n"
+          }
+        },
+        "BallpointSplatling": {
+          "value": "Inkjet",
+          "locale": {
+            "ja": "\u30b8\u30a7\u30c3\u30c8\u30d1\u30c3\u30af",
+            "ko": "\uc81c\ud2b8 \ud329",
+            "zh_TW": "\u5674\u5c04\u80cc\u5305",
+            "zh_CN": "\u55b7\u5c04\u80cc\u5305",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u043b\u0435\u0442",
+            "fr": "Chromo-jet",
+            "nl": "Inktjet",
+            "de": "Tintend\u00fcser",
+            "it": "Jet splat",
+            "es": "Propulsor"
+          }
+        },
+        "Bamboozler14MkI": {
+          "value": "Killer Wail 5.1",
+          "locale": {
+            "ja": "\u30e1\u30ac\u30db\u30f3\u30ec\u30fc\u30b6\u30fc5.1ch",
+            "ko": "\uba54\uac00\ud3f0 \ub808\uc774\uc800 5.1ch",
+            "zh_TW": "\u5587\u53ed\u96f7\u5c045.1ch",
+            "zh_CN": "\u5587\u53ed\u956d\u5c045.1ch",
+            "ru": "\u041c\u0435\u0433\u0430\u043b\u043e\u0444\u043e\u043d 5.1",
+            "nl": "Megalofoon 5.1",
+            "de": "Heulboje 5.1",
+            "it": "Tintofono 5.1",
+            "fr_CA": "Laser per\u00e7ant 5.1",
+            "es": "Tint\u00f3fono 5.1",
+            "es_LA": "Berre\u00f3n 5.1",
+            "fr": "Haut-perceur 5.1"
+          }
+        },
+        "Blaster": {
+          "value": "Big Bubbler",
+          "locale": {
+            "ja": "\u30b0\u30ec\u30fc\u30c8\u30d0\u30ea\u30a2",
+            "ko": "\uadf8\ub808\uc774\ud2b8 \ubc30\ub9ac\uc5b4",
+            "zh_TW": "\u5de8\u5927\u9632\u8b77\u7f69",
+            "zh_CN": "\u5de8\u5927\u9632\u62a4\u7f69",
+            "ru": "\u0428\u0430\u0440\u043e\u0449\u0438\u0442",
+            "fr": "Super bouclier",
+            "nl": "Joekelschild",
+            "de": "Kugelschild Pro",
+            "it": "Gran bolla scudo",
+            "es": "Megaburbuja"
+          }
+        },
+        "Bloblobber": {
+          "value": "Ink Storm",
+          "locale": {
+            "ja": "\u30a2\u30e1\u30d5\u30e9\u30b7",
+            "ko": "\uba39\uad6c\ub984",
+            "zh_TW": "\u58a8\u96e8\u96f2",
+            "zh_CN": "\u58a8\u96e8\u4e91",
+            "ru": "\u0422\u0443\u0447\u0430 \u043a\u0440\u0430\u0441\u043a\u0438",
+            "fr": "Pluie d'encre",
+            "nl": "Spetterbui",
+            "de": "Tintenschauer",
+            "it": "Pioggia di colore",
+            "es": "Atormentador"
+          }
+        },
+        "CarbonRoller": {
+          "value": "Zipcaster",
+          "locale": {
+            "ja": "\u30b7\u30e7\u30af\u30ef\u30f3\u30c0\u30fc",
+            "ko": "\uc1fc\ud06c \uc6d0\ub354",
+            "zh_TW": "\u89f8\u624b\u5674\u5c04",
+            "zh_CN": "\u89e6\u624b\u55b7\u5c04",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0442\u0440\u043e\u0441",
+            "fr": "Super Mollusque",
+            "nl": "Tentakabel",
+            "de": "Haftsprung",
+            "it": "Molluscatto",
+            "es": "Gancho tentacular"
+          }
+        },
+        "ClashBlaster": {
+          "value": "Trizooka",
+          "locale": {
+            "ja": "\u30a6\u30eb\u30c8\u30e9\u30b7\u30e7\u30c3\u30c8",
+            "ko": "\uc6b8\ud2b8\ub77c \uc0f7",
+            "zh_TW": "\u7d42\u6975\u767c\u5c04",
+            "zh_CN": "\u7ec8\u6781\u53d1\u5c04",
+            "ru": "\u0413\u0440\u0430\u043d\u0430\u0442\u043e\u043c\u0435\u0442 \u00ab\u0422\u0440\u0435\u0437\u0443\u0431\u0435\u0446\u00bb",
+            "nl": "Trizooka",
+            "de": "Trizooka",
+            "it": "Ultraturbinator",
+            "fr_CA": "Lance-tornades",
+            "es": "Tintazuca triple",
+            "es_LA": "Ca\u00f1\u00f3n triple",
+            "fr": "Lance-rafales"
+          }
+        },
+        "ClassicSquiffer": {
+          "value": "Big Bubbler",
+          "locale": {
+            "ja": "\u30b0\u30ec\u30fc\u30c8\u30d0\u30ea\u30a2",
+            "ko": "\uadf8\ub808\uc774\ud2b8 \ubc30\ub9ac\uc5b4",
+            "zh_TW": "\u5de8\u5927\u9632\u8b77\u7f69",
+            "zh_CN": "\u5de8\u5927\u9632\u62a4\u7f69",
+            "ru": "\u0428\u0430\u0440\u043e\u0449\u0438\u0442",
+            "fr": "Super bouclier",
+            "nl": "Joekelschild",
+            "de": "Kugelschild Pro",
+            "it": "Gran bolla scudo",
+            "es": "Megaburbuja"
+          }
+        },
+        "DappleDualies": {
+          "value": "Tacticooler",
+          "locale": {
+            "ja": "\u30a8\u30ca\u30b8\u30fc\u30b9\u30bf\u30f3\u30c9",
+            "ko": "\uc5d0\ub108\uc9c0 \uc2a4\ud0e0\ub4dc",
+            "ru": "\u0422\u043e\u043d\u0438\u043a\u0443\u043b\u0435\u0440",
+            "fr": "Districool",
+            "nl": "Reddingsbar",
+            "de": "Tranktank",
+            "it": "Rinfrigorente",
+            "es": "Dispensabebidas"
+          }
+        },
+        "DarkTetraDualies": {
+          "value": "Reefslider",
+          "locale": {
+            "ja": "\u30b5\u30e1\u30e9\u30a4\u30c9",
+            "ko": "\uc0e4\ud06c \ub77c\uc774\ub4dc",
+            "zh_TW": "\u9bca\u9b5a\u5750\u9a0e",
+            "zh_CN": "\u9ca8\u9c7c\u5750\u9a91",
+            "ru": "\u041c\u043e\u0442\u043e\u043a\u0443\u043b\u0430",
+            "fr": "Cavalsquale",
+            "nl": "Opblaashaai",
+            "de": "Haihammer",
+            "it": "Motosqualo",
+            "es": "Flotibur\u00f3n"
+          }
+        },
+        "DualieSquelchers": {
+          "value": "Wave Breaker",
+          "locale": {
+            "ja": "\u30db\u30c3\u30d7\u30bd\u30ca\u30fc",
+            "ko": "\ud649 \uc18c\ub098",
+            "zh_TW": "\u5f48\u8df3\u8072\u7d0d",
+            "zh_CN": "\u5f39\u8df3\u58f0\u5450",
+            "ru": "\u0412\u043e\u043b\u043d\u043e\u043f\u043b\u044e\u0445\u0435\u0440",
+            "fr": "Sonar paf",
+            "nl": "Golfbeker",
+            "de": "Schauerwelle",
+            "it": "Sonar esplosivo",
+            "es": "Emiteondas"
+          }
+        },
+        "DynamoRoller": {
+          "value": "Tacticooler",
+          "locale": {
+            "ja": "\u30a8\u30ca\u30b8\u30fc\u30b9\u30bf\u30f3\u30c9",
+            "ko": "\uc5d0\ub108\uc9c0 \uc2a4\ud0e0\ub4dc",
+            "ru": "\u0422\u043e\u043d\u0438\u043a\u0443\u043b\u0435\u0440",
+            "fr": "Districool",
+            "nl": "Reddingsbar",
+            "de": "Tranktank",
+            "it": "Rinfrigorente",
+            "es": "Dispensabebidas"
+          }
+        },
+        "Eliter4K": {
+          "value": "Wave Breaker",
+          "locale": {
+            "ja": "\u30db\u30c3\u30d7\u30bd\u30ca\u30fc",
+            "ko": "\ud649 \uc18c\ub098",
+            "zh_TW": "\u5f48\u8df3\u8072\u7d0d",
+            "zh_CN": "\u5f39\u8df3\u58f0\u5450",
+            "ru": "\u0412\u043e\u043b\u043d\u043e\u043f\u043b\u044e\u0445\u0435\u0440",
+            "fr": "Sonar paf",
+            "nl": "Golfbeker",
+            "de": "Schauerwelle",
+            "it": "Sonar esplosivo",
+            "es": "Emiteondas"
+          }
+        },
+        "Eliter4KScope": {
+          "value": "Wave Breaker",
+          "locale": {
+            "ja": "\u30db\u30c3\u30d7\u30bd\u30ca\u30fc",
+            "ko": "\ud649 \uc18c\ub098",
+            "zh_TW": "\u5f48\u8df3\u8072\u7d0d",
+            "zh_CN": "\u5f39\u8df3\u58f0\u5450",
+            "ru": "\u0412\u043e\u043b\u043d\u043e\u043f\u043b\u044e\u0445\u0435\u0440",
+            "fr": "Sonar paf",
+            "nl": "Golfbeker",
+            "de": "Schauerwelle",
+            "it": "Sonar esplosivo",
+            "es": "Emiteondas"
+          }
+        },
+        "Explosher": {
+          "value": "Ink Storm",
+          "locale": {
+            "ja": "\u30a2\u30e1\u30d5\u30e9\u30b7",
+            "ko": "\uba39\uad6c\ub984",
+            "zh_TW": "\u58a8\u96e8\u96f2",
+            "zh_CN": "\u58a8\u96e8\u4e91",
+            "ru": "\u0422\u0443\u0447\u0430 \u043a\u0440\u0430\u0441\u043a\u0438",
+            "fr": "Pluie d'encre",
+            "nl": "Spetterbui",
+            "de": "Tintenschauer",
+            "it": "Pioggia di colore",
+            "es": "Atormentador"
+          }
+        },
+        "FlingzaRoller": {
+          "value": "Tenta Missiles",
+          "locale": {
+            "ja": "\u30de\u30eb\u30c1\u30df\u30b5\u30a4\u30eb",
+            "ko": "\uba40\ud2f0 \ubbf8\uc0ac\uc77c",
+            "zh_TW": "\u591a\u91cd\u5c0e\u5f48",
+            "zh_CN": "\u591a\u91cd\u5bfc\u5f39",
+            "ru": "\u041a\u0430\u0440\u0430\u043a\u0430\u0442\u043d\u0438\u0446\u0430",
+            "fr": "Multi-missile",
+            "nl": "Spetterraketten",
+            "de": "Schwarmraketen",
+            "it": "Lanciarazzi",
+            "es": "Lanzamisiles"
+          }
+        },
+        "GloogaDualies": {
+          "value": "Booyah Bomb",
+          "locale": {
+            "ja": "\u30ca\u30a4\u30b9\u30c0\u30de",
+            "ko": "\ub098\uc774\uc2a4\uc625",
+            "zh_TW": "\u8b9a\u6c23\u5f48",
+            "zh_CN": "\u8d5e\u6c14\u5f39",
+            "ru": "\u0419\u043e-\u0445\u043e-\u043f\u043b\u044e\u0445\u0435\u0440",
+            "nl": "Coole bom",
+            "de": "Cool-Kugel",
+            "it": "Granbotto",
+            "es": "Bola genializante",
+            "fr_CA": "Excellinator",
+            "fr": "Jolizator"
+          }
+        },
+        "GooTuber": {
+          "value": "Tenta Missiles",
+          "locale": {
+            "ja": "\u30de\u30eb\u30c1\u30df\u30b5\u30a4\u30eb",
+            "ko": "\uba40\ud2f0 \ubbf8\uc0ac\uc77c",
+            "zh_TW": "\u591a\u91cd\u5c0e\u5f48",
+            "zh_CN": "\u591a\u91cd\u5bfc\u5f39",
+            "ru": "\u041a\u0430\u0440\u0430\u043a\u0430\u0442\u043d\u0438\u0446\u0430",
+            "fr": "Multi-missile",
+            "nl": "Spetterraketten",
+            "de": "Schwarmraketen",
+            "it": "Lanciarazzi",
+            "es": "Lanzamisiles"
+          }
+        },
+        "H3Nozzlenose": {
+          "value": "Tacticooler",
+          "locale": {
+            "ja": "\u30a8\u30ca\u30b8\u30fc\u30b9\u30bf\u30f3\u30c9",
+            "ko": "\uc5d0\ub108\uc9c0 \uc2a4\ud0e0\ub4dc",
+            "ru": "\u0422\u043e\u043d\u0438\u043a\u0443\u043b\u0435\u0440",
+            "fr": "Districool",
+            "nl": "Reddingsbar",
+            "de": "Tranktank",
+            "it": "Rinfrigorente",
+            "es": "Dispensabebidas"
+          }
+        },
+        "HeavySplatling": {
+          "value": "Wave Breaker",
+          "locale": {
+            "ja": "\u30db\u30c3\u30d7\u30bd\u30ca\u30fc",
+            "ko": "\ud649 \uc18c\ub098",
+            "zh_TW": "\u5f48\u8df3\u8072\u7d0d",
+            "zh_CN": "\u5f39\u8df3\u58f0\u5450",
+            "ru": "\u0412\u043e\u043b\u043d\u043e\u043f\u043b\u044e\u0445\u0435\u0440",
+            "fr": "Sonar paf",
+            "nl": "Golfbeker",
+            "de": "Schauerwelle",
+            "it": "Sonar esplosivo",
+            "es": "Emiteondas"
+          }
+        },
+        "HeroShotReplica": {
+          "value": "Trizooka",
+          "locale": {
+            "ja": "\u30a6\u30eb\u30c8\u30e9\u30b7\u30e7\u30c3\u30c8",
+            "ko": "\uc6b8\ud2b8\ub77c \uc0f7",
+            "zh_TW": "\u7d42\u6975\u767c\u5c04",
+            "zh_CN": "\u7ec8\u6781\u53d1\u5c04",
+            "ru": "\u0413\u0440\u0430\u043d\u0430\u0442\u043e\u043c\u0435\u0442 \u00ab\u0422\u0440\u0435\u0437\u0443\u0431\u0435\u0446\u00bb",
+            "nl": "Trizooka",
+            "de": "Trizooka",
+            "it": "Ultraturbinator",
+            "fr_CA": "Lance-tornades",
+            "es": "Tintazuca triple",
+            "es_LA": "Ca\u00f1\u00f3n triple",
+            "fr": "Lance-rafales"
+          }
+        },
+        "HydraSplatling": {
+          "value": "Booyah Bomb",
+          "locale": {
+            "ja": "\u30ca\u30a4\u30b9\u30c0\u30de",
+            "ko": "\ub098\uc774\uc2a4\uc625",
+            "zh_TW": "\u8b9a\u6c23\u5f48",
+            "zh_CN": "\u8d5e\u6c14\u5f39",
+            "ru": "\u0419\u043e-\u0445\u043e-\u043f\u043b\u044e\u0445\u0435\u0440",
+            "nl": "Coole bom",
+            "de": "Cool-Kugel",
+            "it": "Granbotto",
+            "es": "Bola genializante",
+            "fr_CA": "Excellinator",
+            "fr": "Jolizator"
+          }
+        },
+        "Inkbrush": {
+          "value": "Killer Wail 5.1",
+          "locale": {
+            "ja": "\u30e1\u30ac\u30db\u30f3\u30ec\u30fc\u30b6\u30fc5.1ch",
+            "ko": "\uba54\uac00\ud3f0 \ub808\uc774\uc800 5.1ch",
+            "zh_TW": "\u5587\u53ed\u96f7\u5c045.1ch",
+            "zh_CN": "\u5587\u53ed\u956d\u5c045.1ch",
+            "ru": "\u041c\u0435\u0433\u0430\u043b\u043e\u0444\u043e\u043d 5.1",
+            "nl": "Megalofoon 5.1",
+            "de": "Heulboje 5.1",
+            "it": "Tintofono 5.1",
+            "fr_CA": "Laser per\u00e7ant 5.1",
+            "es": "Tint\u00f3fono 5.1",
+            "es_LA": "Berre\u00f3n 5.1",
+            "fr": "Haut-perceur 5.1"
+          }
+        },
+        "JetSquelcher": {
+          "value": "Ink Vac",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30a4\u30f3\u30ad",
+            "ko": "\ud761\uc785\uae30",
+            "zh_TW": "\u5438\u58a8\u6a5f",
+            "zh_CN": "\u5438\u58a8\u673a",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0441\u043e\u0441",
+            "fr": "Aspirencre",
+            "nl": "Inktdief",
+            "de": "Tintegrator",
+            "it": "Vampinchiostro",
+            "es": "Aspiratinta"
+          }
+        },
+        "L3Nozzlenose": {
+          "value": "Crab Tank",
+          "locale": {
+            "ja": "\u30ab\u30cb\u30bf\u30f3\u30af",
+            "ko": "\ud06c\ub7a9 \ud0f1\ud06c",
+            "ru": "\u041a\u0440\u0430\u0431\u043e\u0442\u0430\u043d\u043a",
+            "fr": "Crabe d'assaut",
+            "nl": "Krabbentank",
+            "de": "Krabbenpanzer",
+            "it": "Granchio armato",
+            "es": "Cangrejobot"
+          }
+        },
+        "LunaBlaster": {
+          "value": "Zipcaster",
+          "locale": {
+            "ja": "\u30b7\u30e7\u30af\u30ef\u30f3\u30c0\u30fc",
+            "ko": "\uc1fc\ud06c \uc6d0\ub354",
+            "zh_TW": "\u89f8\u624b\u5674\u5c04",
+            "zh_CN": "\u89e6\u624b\u55b7\u5c04",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0442\u0440\u043e\u0441",
+            "fr": "Super Mollusque",
+            "nl": "Tentakabel",
+            "de": "Haftsprung",
+            "it": "Molluscatto",
+            "es": "Gancho tentacular"
+          }
+        },
+        "MiniSplatling": {
+          "value": "Ultra Stamp",
+          "locale": {
+            "ja": "\u30a6\u30eb\u30c8\u30e9\u30cf\u30f3\u30b3",
+            "ko": "\uc6b8\ud2b8\ub77c \uc2a4\ud0ec\ud504",
+            "zh_TW": "\u7d42\u6975\u5370\u7ae0",
+            "zh_CN": "\u7ec8\u6781\u5370\u7ae0",
+            "ru": "\u041f\u0440\u0438\u043f\u0435\u0447\u0430\u0442\u044c",
+            "nl": "Ultrastempel",
+            "de": "Ultra-Stempel",
+            "it": "Mega timbro",
+            "es": "Ultraselladora",
+            "fr_CA": "Ultra-\u00e9tampeur",
+            "fr": "Ultra-tamponneur"
+          }
+        },
+        "NZAP'85": {
+          "value": "Tacticooler",
+          "locale": {
+            "ja": "\u30a8\u30ca\u30b8\u30fc\u30b9\u30bf\u30f3\u30c9",
+            "ko": "\uc5d0\ub108\uc9c0 \uc2a4\ud0e0\ub4dc",
+            "ru": "\u0422\u043e\u043d\u0438\u043a\u0443\u043b\u0435\u0440",
+            "fr": "Districool",
+            "nl": "Reddingsbar",
+            "de": "Tranktank",
+            "it": "Rinfrigorente",
+            "es": "Dispensabebidas"
+          }
+        },
+        "Nautilus47": {
+          "value": "Ink Storm",
+          "locale": {
+            "ja": "\u30a2\u30e1\u30d5\u30e9\u30b7",
+            "ko": "\uba39\uad6c\ub984",
+            "zh_TW": "\u58a8\u96e8\u96f2",
+            "zh_CN": "\u58a8\u96e8\u4e91",
+            "ru": "\u0422\u0443\u0447\u0430 \u043a\u0440\u0430\u0441\u043a\u0438",
+            "fr": "Pluie d'encre",
+            "nl": "Spetterbui",
+            "de": "Tintenschauer",
+            "it": "Pioggia di colore",
+            "es": "Atormentador"
+          }
+        },
+        "Octobrush": {
+          "value": "Zipcaster",
+          "locale": {
+            "ja": "\u30b7\u30e7\u30af\u30ef\u30f3\u30c0\u30fc",
+            "ko": "\uc1fc\ud06c \uc6d0\ub354",
+            "zh_TW": "\u89f8\u624b\u5674\u5c04",
+            "zh_CN": "\u89e6\u624b\u55b7\u5c04",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0442\u0440\u043e\u0441",
+            "fr": "Super Mollusque",
+            "nl": "Tentakabel",
+            "de": "Haftsprung",
+            "it": "Molluscatto",
+            "es": "Gancho tentacular"
+          }
+        },
+        "RangeBlaster": {
+          "value": "Wave Breaker",
+          "locale": {
+            "ja": "\u30db\u30c3\u30d7\u30bd\u30ca\u30fc",
+            "ko": "\ud649 \uc18c\ub098",
+            "zh_TW": "\u5f48\u8df3\u8072\u7d0d",
+            "zh_CN": "\u5f39\u8df3\u58f0\u5450",
+            "ru": "\u0412\u043e\u043b\u043d\u043e\u043f\u043b\u044e\u0445\u0435\u0440",
+            "fr": "Sonar paf",
+            "nl": "Golfbeker",
+            "de": "Schauerwelle",
+            "it": "Sonar esplosivo",
+            "es": "Emiteondas"
+          }
+        },
+        "RapidBlaster": {
+          "value": "Triple Inkstrike",
+          "locale": {
+            "ja": "\u30c8\u30ea\u30d7\u30eb\u30c8\u30eb\u30cd\u30fc\u30c9",
+            "ko": "\ud2b8\ub9ac\ud50c \ud1a0\ub124\uc774\ub3c4",
+            "zh_TW": "\u4e09\u91cd\u9f8d\u6372\u98a8",
+            "zh_CN": "\u4e09\u91cd\u9f99\u5377\u98ce",
+            "ru": "\u0422\u0440\u043e\u0439\u043d\u043e\u0435 \u0442\u043e\u0440\u043d\u0430\u0434\u043e",
+            "fr": "Trimissile tornade",
+            "nl": "Tri-tornado",
+            "de": "Tri-Tintferno",
+            "it": "Triplo tornado",
+            "es": "Tornado triple"
+          }
+        },
+        "RapidBlasterPro": {
+          "value": "Ink Vac",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30a4\u30f3\u30ad",
+            "ko": "\ud761\uc785\uae30",
+            "zh_TW": "\u5438\u58a8\u6a5f",
+            "zh_CN": "\u5438\u58a8\u673a",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0441\u043e\u0441",
+            "fr": "Aspirencre",
+            "nl": "Inktdief",
+            "de": "Tintegrator",
+            "it": "Vampinchiostro",
+            "es": "Aspiratinta"
+          }
+        },
+        "REEFLUX450": {
+          "value": "Tenta Missiles",
+          "locale": {
+            "ja": "\u30de\u30eb\u30c1\u30df\u30b5\u30a4\u30eb",
+            "ko": "\uba40\ud2f0 \ubbf8\uc0ac\uc77c",
+            "zh_TW": "\u591a\u91cd\u5c0e\u5f48",
+            "zh_CN": "\u591a\u91cd\u5bfc\u5f39",
+            "ru": "\u041a\u0430\u0440\u0430\u043a\u0430\u0442\u043d\u0438\u0446\u0430",
+            "fr": "Multi-missile",
+            "nl": "Spetterraketten",
+            "de": "Schwarmraketen",
+            "it": "Lanciarazzi",
+            "es": "Lanzamisiles"
+          }
+        },
+        "Slosher": {
+          "value": "Triple Inkstrike",
+          "locale": {
+            "ja": "\u30c8\u30ea\u30d7\u30eb\u30c8\u30eb\u30cd\u30fc\u30c9",
+            "ko": "\ud2b8\ub9ac\ud50c \ud1a0\ub124\uc774\ub3c4",
+            "zh_TW": "\u4e09\u91cd\u9f8d\u6372\u98a8",
+            "zh_CN": "\u4e09\u91cd\u9f99\u5377\u98ce",
+            "ru": "\u0422\u0440\u043e\u0439\u043d\u043e\u0435 \u0442\u043e\u0440\u043d\u0430\u0434\u043e",
+            "fr": "Trimissile tornade",
+            "nl": "Tri-tornado",
+            "de": "Tri-Tintferno",
+            "it": "Triplo tornado",
+            "es": "Tornado triple"
+          }
+        },
+        "SloshingMachine": {
+          "value": "Booyah Bomb",
+          "locale": {
+            "ja": "\u30ca\u30a4\u30b9\u30c0\u30de",
+            "ko": "\ub098\uc774\uc2a4\uc625",
+            "zh_TW": "\u8b9a\u6c23\u5f48",
+            "zh_CN": "\u8d5e\u6c14\u5f39",
+            "ru": "\u0419\u043e-\u0445\u043e-\u043f\u043b\u044e\u0445\u0435\u0440",
+            "nl": "Coole bom",
+            "de": "Cool-Kugel",
+            "it": "Granbotto",
+            "es": "Bola genializante",
+            "fr_CA": "Excellinator",
+            "fr": "Jolizator"
+          }
+        },
+        "Splashomatic": {
+          "value": "Crab Tank",
+          "locale": {
+            "ja": "\u30ab\u30cb\u30bf\u30f3\u30af",
+            "ko": "\ud06c\ub7a9 \ud0f1\ud06c",
+            "ru": "\u041a\u0440\u0430\u0431\u043e\u0442\u0430\u043d\u043a",
+            "fr": "Crabe d'assaut",
+            "nl": "Krabbentank",
+            "de": "Krabbenpanzer",
+            "it": "Granchio armato",
+            "es": "Cangrejobot"
+          }
+        },
+        "SplatBrella": {
+          "value": "Triple Inkstrike",
+          "locale": {
+            "ja": "\u30c8\u30ea\u30d7\u30eb\u30c8\u30eb\u30cd\u30fc\u30c9",
+            "ko": "\ud2b8\ub9ac\ud50c \ud1a0\ub124\uc774\ub3c4",
+            "zh_TW": "\u4e09\u91cd\u9f8d\u6372\u98a8",
+            "zh_CN": "\u4e09\u91cd\u9f99\u5377\u98ce",
+            "ru": "\u0422\u0440\u043e\u0439\u043d\u043e\u0435 \u0442\u043e\u0440\u043d\u0430\u0434\u043e",
+            "fr": "Trimissile tornade",
+            "nl": "Tri-tornado",
+            "de": "Tri-Tintferno",
+            "it": "Triplo tornado",
+            "es": "Tornado triple"
+          }
+        },
+        "SplatCharger": {
+          "value": "Ink Vac",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30a4\u30f3\u30ad",
+            "ko": "\ud761\uc785\uae30",
+            "zh_TW": "\u5438\u58a8\u6a5f",
+            "zh_CN": "\u5438\u58a8\u673a",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0441\u043e\u0441",
+            "fr": "Aspirencre",
+            "nl": "Inktdief",
+            "de": "Tintegrator",
+            "it": "Vampinchiostro",
+            "es": "Aspiratinta"
+          }
+        },
+        "SplatDualies": {
+          "value": "Crab Tank",
+          "locale": {
+            "ja": "\u30ab\u30cb\u30bf\u30f3\u30af",
+            "ko": "\ud06c\ub7a9 \ud0f1\ud06c",
+            "ru": "\u041a\u0440\u0430\u0431\u043e\u0442\u0430\u043d\u043a",
+            "fr": "Crabe d'assaut",
+            "nl": "Krabbentank",
+            "de": "Krabbenpanzer",
+            "it": "Granchio armato",
+            "es": "Cangrejobot"
+          }
+        },
+        "SplatRoller": {
+          "value": "Big Bubbler",
+          "locale": {
+            "ja": "\u30b0\u30ec\u30fc\u30c8\u30d0\u30ea\u30a2",
+            "ko": "\uadf8\ub808\uc774\ud2b8 \ubc30\ub9ac\uc5b4",
+            "zh_TW": "\u5de8\u5927\u9632\u8b77\u7f69",
+            "zh_CN": "\u5de8\u5927\u9632\u62a4\u7f69",
+            "ru": "\u0428\u0430\u0440\u043e\u0449\u0438\u0442",
+            "fr": "Super bouclier",
+            "nl": "Joekelschild",
+            "de": "Kugelschild Pro",
+            "it": "Gran bolla scudo",
+            "es": "Megaburbuja"
+          }
+        },
+        "SplatanaStamper": {
+          "value": "Zipcaster",
+          "locale": {
+            "ja": "\u30b7\u30e7\u30af\u30ef\u30f3\u30c0\u30fc",
+            "ko": "\uc1fc\ud06c \uc6d0\ub354",
+            "zh_TW": "\u89f8\u624b\u5674\u5c04",
+            "zh_CN": "\u89e6\u624b\u55b7\u5c04",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0442\u0440\u043e\u0441",
+            "fr": "Super Mollusque",
+            "nl": "Tentakabel",
+            "de": "Haftsprung",
+            "it": "Molluscatto",
+            "es": "Gancho tentacular"
+          }
+        },
+        "SplatanaWiper": {
+          "value": "Ultra Stamp",
+          "locale": {
+            "ja": "\u30a6\u30eb\u30c8\u30e9\u30cf\u30f3\u30b3",
+            "ko": "\uc6b8\ud2b8\ub77c \uc2a4\ud0ec\ud504",
+            "zh_TW": "\u7d42\u6975\u5370\u7ae0",
+            "zh_CN": "\u7ec8\u6781\u5370\u7ae0",
+            "ru": "\u041f\u0440\u0438\u043f\u0435\u0447\u0430\u0442\u044c",
+            "nl": "Ultrastempel",
+            "de": "Ultra-Stempel",
+            "it": "Mega timbro",
+            "es": "Ultraselladora",
+            "fr_CA": "Ultra-\u00e9tampeur",
+            "fr": "Ultra-tamponneur"
+          }
+        },
+        "Splatterscope": {
+          "value": "Ink Vac",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30a4\u30f3\u30ad",
+            "ko": "\ud761\uc785\uae30",
+            "zh_TW": "\u5438\u58a8\u6a5f",
+            "zh_CN": "\u5438\u58a8\u673a",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0441\u043e\u0441",
+            "fr": "Aspirencre",
+            "nl": "Inktdief",
+            "de": "Tintegrator",
+            "it": "Vampinchiostro",
+            "es": "Aspiratinta"
+          }
+        },
+        "Splattershot": {
+          "value": "Trizooka",
+          "locale": {
+            "ja": "\u30a6\u30eb\u30c8\u30e9\u30b7\u30e7\u30c3\u30c8",
+            "ko": "\uc6b8\ud2b8\ub77c \uc0f7",
+            "zh_TW": "\u7d42\u6975\u767c\u5c04",
+            "zh_CN": "\u7ec8\u6781\u53d1\u5c04",
+            "ru": "\u0413\u0440\u0430\u043d\u0430\u0442\u043e\u043c\u0435\u0442 \u00ab\u0422\u0440\u0435\u0437\u0443\u0431\u0435\u0446\u00bb",
+            "nl": "Trizooka",
+            "de": "Trizooka",
+            "it": "Ultraturbinator",
+            "fr_CA": "Lance-tornades",
+            "es": "Tintazuca triple",
+            "es_LA": "Ca\u00f1\u00f3n triple",
+            "fr": "Lance-rafales"
+          }
+        },
+        "SplattershotJr": {
+          "value": "Big Bubbler",
+          "locale": {
+            "ja": "\u30b0\u30ec\u30fc\u30c8\u30d0\u30ea\u30a2",
+            "ko": "\uadf8\ub808\uc774\ud2b8 \ubc30\ub9ac\uc5b4",
+            "zh_TW": "\u5de8\u5927\u9632\u8b77\u7f69",
+            "zh_CN": "\u5de8\u5927\u9632\u62a4\u7f69",
+            "ru": "\u0428\u0430\u0440\u043e\u0449\u0438\u0442",
+            "fr": "Super bouclier",
+            "nl": "Joekelschild",
+            "de": "Kugelschild Pro",
+            "it": "Gran bolla scudo",
+            "es": "Megaburbuja"
+          }
+        },
+        "SplattershotPro": {
+          "value": "Crab Tank",
+          "locale": {
+            "ja": "\u30ab\u30cb\u30bf\u30f3\u30af",
+            "ko": "\ud06c\ub7a9 \ud0f1\ud06c",
+            "ru": "\u041a\u0440\u0430\u0431\u043e\u0442\u0430\u043d\u043a",
+            "fr": "Crabe d'assaut",
+            "nl": "Krabbentank",
+            "de": "Krabbenpanzer",
+            "it": "Granchio armato",
+            "es": "Cangrejobot"
+          }
+        },
+        "Splooshomatic": {
+          "value": "Ultra Stamp",
+          "locale": {
+            "ja": "\u30a6\u30eb\u30c8\u30e9\u30cf\u30f3\u30b3",
+            "ko": "\uc6b8\ud2b8\ub77c \uc2a4\ud0ec\ud504",
+            "zh_TW": "\u7d42\u6975\u5370\u7ae0",
+            "zh_CN": "\u7ec8\u6781\u5370\u7ae0",
+            "ru": "\u041f\u0440\u0438\u043f\u0435\u0447\u0430\u0442\u044c",
+            "nl": "Ultrastempel",
+            "de": "Ultra-Stempel",
+            "it": "Mega timbro",
+            "es": "Ultraselladora",
+            "fr_CA": "Ultra-\u00e9tampeur",
+            "fr": "Ultra-tamponneur"
+          }
+        },
+        "Squeezer": {
+          "value": "Trizooka",
+          "locale": {
+            "ja": "\u30a6\u30eb\u30c8\u30e9\u30b7\u30e7\u30c3\u30c8",
+            "ko": "\uc6b8\ud2b8\ub77c \uc0f7",
+            "zh_TW": "\u7d42\u6975\u767c\u5c04",
+            "zh_CN": "\u7ec8\u6781\u53d1\u5c04",
+            "ru": "\u0413\u0440\u0430\u043d\u0430\u0442\u043e\u043c\u0435\u0442 \u00ab\u0422\u0440\u0435\u0437\u0443\u0431\u0435\u0446\u00bb",
+            "nl": "Trizooka",
+            "de": "Trizooka",
+            "it": "Ultraturbinator",
+            "fr_CA": "Lance-tornades",
+            "es": "Tintazuca triple",
+            "es_LA": "Ca\u00f1\u00f3n triple",
+            "fr": "Lance-rafales"
+          }
+        },
+        "TentaBrella": {
+          "value": "Ink Vac",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30a4\u30f3\u30ad",
+            "ko": "\ud761\uc785\uae30",
+            "zh_TW": "\u5438\u58a8\u6a5f",
+            "zh_CN": "\u5438\u58a8\u673a",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u0441\u043e\u0441",
+            "fr": "Aspirencre",
+            "nl": "Inktdief",
+            "de": "Tintegrator",
+            "it": "Vampinchiostro",
+            "es": "Aspiratinta"
+          }
+        },
+        "TriSlosher": {
+          "value": "Inkjet",
+          "locale": {
+            "ja": "\u30b8\u30a7\u30c3\u30c8\u30d1\u30c3\u30af",
+            "ko": "\uc81c\ud2b8 \ud329",
+            "zh_TW": "\u5674\u5c04\u80cc\u5305",
+            "zh_CN": "\u55b7\u5c04\u80cc\u5305",
+            "ru": "\u041a\u0440\u0430\u0441\u043a\u043e\u043b\u0435\u0442",
+            "fr": "Chromo-jet",
+            "nl": "Inktjet",
+            "de": "Tintend\u00fcser",
+            "it": "Jet splat",
+            "es": "Propulsor"
+          }
+        },
+        "TriStringer": {
+          "value": "Killer Wail 5.1",
+          "locale": {
+            "ja": "\u30e1\u30ac\u30db\u30f3\u30ec\u30fc\u30b6\u30fc5.1ch",
+            "ko": "\uba54\uac00\ud3f0 \ub808\uc774\uc800 5.1ch",
+            "zh_TW": "\u5587\u53ed\u96f7\u5c045.1ch",
+            "zh_CN": "\u5587\u53ed\u956d\u5c045.1ch",
+            "ru": "\u041c\u0435\u0433\u0430\u043b\u043e\u0444\u043e\u043d 5.1",
+            "nl": "Megalofoon 5.1",
+            "de": "Heulboje 5.1",
+            "it": "Tintofono 5.1",
+            "fr_CA": "Laser per\u00e7ant 5.1",
+            "es": "Tint\u00f3fono 5.1",
+            "es_LA": "Berre\u00f3n 5.1",
+            "fr": "Haut-perceur 5.1"
+          }
+        },
+        "UndercoverBrella": {
+          "value": "Reefslider",
+          "locale": {
+            "ja": "\u30b5\u30e1\u30e9\u30a4\u30c9",
+            "ko": "\uc0e4\ud06c \ub77c\uc774\ub4dc",
+            "zh_TW": "\u9bca\u9b5a\u5750\u9a0e",
+            "zh_CN": "\u9ca8\u9c7c\u5750\u9a91",
+            "ru": "\u041c\u043e\u0442\u043e\u043a\u0443\u043b\u0430",
+            "fr": "Cavalsquale",
+            "nl": "Opblaashaai",
+            "de": "Haihammer",
+            "it": "Motosqualo",
+            "es": "Flotibur\u00f3n"
+          }
+        }
+      }
+    }
+  ],
   "uncropped_edge": [
       "u",
       "d",

--- a/games/spl3/sub/config.json
+++ b/games/spl3/sub/config.json
@@ -8,8 +8,8 @@
     "sub"
   ],
   "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
-  "extra_data": [
-    {
+  "extra_data": {
+    "sub_name": {
       "title": "Sub weapon",
       "locale": {
         "fr": "Arme secondaire"
@@ -871,11 +871,11 @@
         }
       }
     }
-  ],
+  },
   "uncropped_edge": [
-      "u",
-      "d",
-      "l",
-      "r"
+    "u",
+    "d",
+    "l",
+    "r"
   ]
 }

--- a/games/spl3/sub/config.json
+++ b/games/spl3/sub/config.json
@@ -8,7 +8,7 @@
     "sub"
   ],
   "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
-  "extra_data": {
+  "metadata": {
     "sub_name": {
       "title": "Sub weapon",
       "locale": {

--- a/games/spl3/sub/config.json
+++ b/games/spl3/sub/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Sub Icons",
-  "version": "1.1",
+  "version": "1.11",
   "description": "Sub weapon icons",
   "prefix": "sub_",
   "postfix": "_",
@@ -8,6 +8,870 @@
     "sub"
   ],
   "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
+  "extra_data": [
+    {
+      "title": "Sub weapon",
+      "locale": {
+        "fr": "Arme secondaire"
+      },
+      "values": {
+        "52Gal": {
+          "value": "Splash Wall",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30b7\u30fc\u30eb\u30c9",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \uc2e4\ub4dc",
+            "zh_TW": "\u65af\u666e\u62c9\u9632\u8b77\u7246",
+            "zh_CN": "\u65af\u666e\u62c9\u9632\u62a4\u5899",
+            "ru": "\u0427\u0435\u0440\u043d\u0438\u043b\u044c\u043d\u044b\u0439 \u0437\u0430\u043d\u0430\u0432\u0435\u0441",
+            "fr": "Mur d'encre",
+            "nl": "Inktgordijn",
+            "de": "Tintenwall",
+            "it": "Muro di colore",
+            "es": "Tel\u00f3n de Tinta",
+            "es_LA": "Barricada"
+          }
+        },
+        "96Gal": {
+          "value": "Sprinkler",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30ea\u30f3\u30af\u30e9\u30fc",
+            "ko": "\uc2a4\ud504\ub9c1\ud074\ub7ec",
+            "zh_TW": "\u7051\u58a8\u5668",
+            "zh_CN": "\u6d12\u58a8\u5668",
+            "ru": "\u0420\u0430\u0441\u043f\u044b\u043b\u044f\u0442\u043e\u0440",
+            "nl": "Inktsprinkler",
+            "de": "Sprinkler",
+            "it": "Spruzzatore",
+            "es": "Aspersor",
+            "fr_CA": "Gicleur",
+            "fr": "Fontaine"
+          }
+        },
+        "AerosprayMG": {
+          "value": "Fizzy Bomb",
+          "locale": {
+            "ja": "\u30bf\u30f3\u30b5\u30f3\u30dc\u30e0",
+            "ko": "\ud0c4\uc0b0 \ubc24",
+            "zh_TW": "\u78b3\u9178\u70b8\u5f48",
+            "zh_CN": "\u78b3\u9178\u70b8\u5f39",
+            "ru": "\u0421\u043e\u0434\u043e\u0432\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe soda",
+            "nl": "Bomblikje",
+            "de": "Sprudel-Bombe",
+            "it": "Bomba a gassosa",
+            "es": "Bomba carb\u00f3nica"
+          }
+        },
+        "BallpointSplatling": {
+          "value": "Fizzy Bomb",
+          "locale": {
+            "ja": "\u30bf\u30f3\u30b5\u30f3\u30dc\u30e0",
+            "ko": "\ud0c4\uc0b0 \ubc24",
+            "zh_TW": "\u78b3\u9178\u70b8\u5f48",
+            "zh_CN": "\u78b3\u9178\u70b8\u5f39",
+            "ru": "\u0421\u043e\u0434\u043e\u0432\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe soda",
+            "nl": "Bomblikje",
+            "de": "Sprudel-Bombe",
+            "it": "Bomba a gassosa",
+            "es": "Bomba carb\u00f3nica"
+          }
+        },
+        "Bamboozler14MkI": {
+          "value": "Autobomb",
+          "locale": {
+            "ja": "\u30ed\u30dc\u30c3\u30c8\u30dc\u30e0",
+            "ko": "\ub85c\ubd07 \ubc24",
+            "zh_TW": "\u6a5f\u5668\u4eba\u70b8\u5f48",
+            "zh_CN": "\u673a\u5668\u4eba\u70b8\u5f39",
+            "ru": "\u0420\u043e\u0431\u043e\u0431\u043e\u043c\u0431",
+            "fr": "Bombe robot",
+            "nl": "Robobom",
+            "de": "Robo-Bombe",
+            "it": "Robobomba",
+            "es": "Robobomba"
+          }
+        },
+        "Blaster": {
+          "value": "Autobomb",
+          "locale": {
+            "ja": "\u30ed\u30dc\u30c3\u30c8\u30dc\u30e0",
+            "ko": "\ub85c\ubd07 \ubc24",
+            "zh_TW": "\u6a5f\u5668\u4eba\u70b8\u5f48",
+            "zh_CN": "\u673a\u5668\u4eba\u70b8\u5f39",
+            "ru": "\u0420\u043e\u0431\u043e\u0431\u043e\u043c\u0431",
+            "fr": "Bombe robot",
+            "nl": "Robobom",
+            "de": "Robo-Bombe",
+            "it": "Robobomba",
+            "es": "Robobomba"
+          }
+        },
+        "Bloblobber": {
+          "value": "Sprinkler",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30ea\u30f3\u30af\u30e9\u30fc",
+            "ko": "\uc2a4\ud504\ub9c1\ud074\ub7ec",
+            "zh_TW": "\u7051\u58a8\u5668",
+            "zh_CN": "\u6d12\u58a8\u5668",
+            "ru": "\u0420\u0430\u0441\u043f\u044b\u043b\u044f\u0442\u043e\u0440",
+            "nl": "Inktsprinkler",
+            "de": "Sprinkler",
+            "it": "Spruzzatore",
+            "es": "Aspersor",
+            "fr_CA": "Gicleur",
+            "fr": "Fontaine"
+          }
+        },
+        "CarbonRoller": {
+          "value": "Autobomb",
+          "locale": {
+            "ja": "\u30ed\u30dc\u30c3\u30c8\u30dc\u30e0",
+            "ko": "\ub85c\ubd07 \ubc24",
+            "zh_TW": "\u6a5f\u5668\u4eba\u70b8\u5f48",
+            "zh_CN": "\u673a\u5668\u4eba\u70b8\u5f39",
+            "ru": "\u0420\u043e\u0431\u043e\u0431\u043e\u043c\u0431",
+            "fr": "Bombe robot",
+            "nl": "Robobom",
+            "de": "Robo-Bombe",
+            "it": "Robobomba",
+            "es": "Robobomba"
+          }
+        },
+        "ClashBlaster": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "ClassicSquiffer": {
+          "value": "Point Sensor",
+          "locale": {
+            "ja": "\u30dd\u30a4\u30f3\u30c8\u30bb\u30f3\u30b5\u30fc",
+            "ko": "\ud3ec\uc778\ud2b8 \uc13c\uc11c",
+            "zh_TW": "\u5b9a\u9ede\u5075\u6e2c\u5668",
+            "zh_CN": "\u5b9a\u70b9\u4fa6\u6d4b\u5668",
+            "ru": "\u041c\u0430\u0440\u043a\u0435\u0440 \u0434\u0432\u0438\u0436\u0435\u043d\u0438\u044f",
+            "fr": "D\u00e9tecteur",
+            "nl": "Detector",
+            "de": "Detektor",
+            "it": "Cimice",
+            "es": "Rastreador"
+          }
+        },
+        "DappleDualies": {
+          "value": "Squid Beakon",
+          "locale": {
+            "ja": "\u30b8\u30e3\u30f3\u30d7\u30d3\u30fc\u30b3\u30f3",
+            "ko": "\uc810\ud504 \ube44\ucee8",
+            "zh_TW": "\u8df3\u8e8d\u4fe1\u6a19",
+            "zh_CN": "\u8df3\u8dc3\u4fe1\u6807",
+            "ru": "\u041f\u0440\u044b\u0436\u043a\u043e\u0432\u044b\u0439 \u043c\u0430\u044f\u0447\u043e\u043a",
+            "fr": "Balise de saut",
+            "nl": "Springschotel",
+            "de": "Sprungboje",
+            "it": "Trasferitore",
+            "es": "Baliza transportadora",
+            "es_LA": "Baliza"
+          }
+        },
+        "DarkTetraDualies": {
+          "value": "Autobomb",
+          "locale": {
+            "ja": "\u30ed\u30dc\u30c3\u30c8\u30dc\u30e0",
+            "ko": "\ub85c\ubd07 \ubc24",
+            "zh_TW": "\u6a5f\u5668\u4eba\u70b8\u5f48",
+            "zh_CN": "\u673a\u5668\u4eba\u70b8\u5f39",
+            "ru": "\u0420\u043e\u0431\u043e\u0431\u043e\u043c\u0431",
+            "fr": "Bombe robot",
+            "nl": "Robobom",
+            "de": "Robo-Bombe",
+            "it": "Robobomba",
+            "es": "Robobomba"
+          }
+        },
+        "DualieSquelchers": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "DynamoRoller": {
+          "value": "Sprinkler",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30ea\u30f3\u30af\u30e9\u30fc",
+            "ko": "\uc2a4\ud504\ub9c1\ud074\ub7ec",
+            "zh_TW": "\u7051\u58a8\u5668",
+            "zh_CN": "\u6d12\u58a8\u5668",
+            "ru": "\u0420\u0430\u0441\u043f\u044b\u043b\u044f\u0442\u043e\u0440",
+            "nl": "Inktsprinkler",
+            "de": "Sprinkler",
+            "it": "Spruzzatore",
+            "es": "Aspersor",
+            "fr_CA": "Gicleur",
+            "fr": "Fontaine"
+          }
+        },
+        "Eliter4K": {
+          "value": "Ink Mine",
+          "locale": {
+            "ja": "\u30c8\u30e9\u30c3\u30d7",
+            "ko": "\ud2b8\ub7a9",
+            "ru": "\u041c\u0438\u043d\u044b",
+            "nl": "Inktmijn",
+            "de": "Tintenmine",
+            "it": "Mina",
+            "fr_CA": "Mine d'encre",
+            "es": "Bomba Trampa",
+            "es_LA": "Mina de tinta",
+            "fr": "Mine"
+          }
+        },
+        "Eliter4KScope": {
+          "value": "Ink Mine",
+          "locale": {
+            "ja": "\u30c8\u30e9\u30c3\u30d7",
+            "ko": "\ud2b8\ub7a9",
+            "ru": "\u041c\u0438\u043d\u044b",
+            "nl": "Inktmijn",
+            "de": "Tintenmine",
+            "it": "Mina",
+            "fr_CA": "Mine d'encre",
+            "es": "Bomba Trampa",
+            "es_LA": "Mina de tinta",
+            "fr": "Mine"
+          }
+        },
+        "Explosher": {
+          "value": "Point Sensor",
+          "locale": {
+            "ja": "\u30dd\u30a4\u30f3\u30c8\u30bb\u30f3\u30b5\u30fc",
+            "ko": "\ud3ec\uc778\ud2b8 \uc13c\uc11c",
+            "zh_TW": "\u5b9a\u9ede\u5075\u6e2c\u5668",
+            "zh_CN": "\u5b9a\u70b9\u4fa6\u6d4b\u5668",
+            "ru": "\u041c\u0430\u0440\u043a\u0435\u0440 \u0434\u0432\u0438\u0436\u0435\u043d\u0438\u044f",
+            "fr": "D\u00e9tecteur",
+            "nl": "Detector",
+            "de": "Detektor",
+            "it": "Cimice",
+            "es": "Rastreador"
+          }
+        },
+        "FlingzaRoller": {
+          "value": "Ink Mine",
+          "locale": {
+            "ja": "\u30c8\u30e9\u30c3\u30d7",
+            "ko": "\ud2b8\ub7a9",
+            "ru": "\u041c\u0438\u043d\u044b",
+            "nl": "Inktmijn",
+            "de": "Tintenmine",
+            "it": "Mina",
+            "fr_CA": "Mine d'encre",
+            "es": "Bomba Trampa",
+            "es_LA": "Mina de tinta",
+            "fr": "Mine"
+          }
+        },
+        "GloogaDualies": {
+          "value": "Splash Wall",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30b7\u30fc\u30eb\u30c9",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \uc2e4\ub4dc",
+            "zh_TW": "\u65af\u666e\u62c9\u9632\u8b77\u7246",
+            "zh_CN": "\u65af\u666e\u62c9\u9632\u62a4\u5899",
+            "ru": "\u0427\u0435\u0440\u043d\u0438\u043b\u044c\u043d\u044b\u0439 \u0437\u0430\u043d\u0430\u0432\u0435\u0441",
+            "fr": "Mur d'encre",
+            "nl": "Inktgordijn",
+            "de": "Tintenwall",
+            "it": "Muro di colore",
+            "es": "Tel\u00f3n de Tinta",
+            "es_LA": "Barricada"
+          }
+        },
+        "GooTuber": {
+          "value": "Torpedo",
+          "locale": {
+            "ja": "\u30c8\u30fc\u30d4\u30fc\u30c9",
+            "ko": "\ud1a0\ud53c\ub3c4",
+            "zh_TW": "\u9b5a\u96f7",
+            "zh_CN": "\u9c7c\u96f7",
+            "ru": "\u0422\u043e\u0440\u043f\u0435\u0434\u043d\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bentorpille",
+            "nl": "Torpedobom",
+            "de": "Torpedo",
+            "it": "Torpedinatore",
+            "es": "Torpedo"
+          }
+        },
+        "H3Nozzlenose": {
+          "value": "Point Sensor",
+          "locale": {
+            "ja": "\u30dd\u30a4\u30f3\u30c8\u30bb\u30f3\u30b5\u30fc",
+            "ko": "\ud3ec\uc778\ud2b8 \uc13c\uc11c",
+            "zh_TW": "\u5b9a\u9ede\u5075\u6e2c\u5668",
+            "zh_CN": "\u5b9a\u70b9\u4fa6\u6d4b\u5668",
+            "ru": "\u041c\u0430\u0440\u043a\u0435\u0440 \u0434\u0432\u0438\u0436\u0435\u043d\u0438\u044f",
+            "fr": "D\u00e9tecteur",
+            "nl": "Detector",
+            "de": "Detektor",
+            "it": "Cimice",
+            "es": "Rastreador"
+          }
+        },
+        "HeavySplatling": {
+          "value": "Sprinkler",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30ea\u30f3\u30af\u30e9\u30fc",
+            "ko": "\uc2a4\ud504\ub9c1\ud074\ub7ec",
+            "zh_TW": "\u7051\u58a8\u5668",
+            "zh_CN": "\u6d12\u58a8\u5668",
+            "ru": "\u0420\u0430\u0441\u043f\u044b\u043b\u044f\u0442\u043e\u0440",
+            "nl": "Inktsprinkler",
+            "de": "Sprinkler",
+            "it": "Spruzzatore",
+            "es": "Aspersor",
+            "fr_CA": "Gicleur",
+            "fr": "Fontaine"
+          }
+        },
+        "HeroShotReplica": {
+          "value": "Suction Bomb",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30d0\u30f3\u30dc\u30e0",
+            "ko": "\ube68\ud310 \ubc24",
+            "zh_TW": "\u5438\u76e4\u70b8\u5f48",
+            "zh_CN": "\u5438\u76d8\u70b8\u5f39",
+            "ru": "\u0411\u043e\u043c\u0431\u0430 \u043d\u0430 \u043f\u0440\u0438\u0441\u043e\u0441\u043a\u0435",
+            "fr": "Bombe gluante",
+            "nl": "Kleefbom",
+            "de": "Haftbombe",
+            "it": "Appiccibomba",
+            "es": "Bomba ventosa",
+            "es_LA": "Bomba pegajosa"
+          }
+        },
+        "HydraSplatling": {
+          "value": "Autobomb",
+          "locale": {
+            "ja": "\u30ed\u30dc\u30c3\u30c8\u30dc\u30e0",
+            "ko": "\ub85c\ubd07 \ubc24",
+            "zh_TW": "\u6a5f\u5668\u4eba\u70b8\u5f48",
+            "zh_CN": "\u673a\u5668\u4eba\u70b8\u5f39",
+            "ru": "\u0420\u043e\u0431\u043e\u0431\u043e\u043c\u0431",
+            "fr": "Bombe robot",
+            "nl": "Robobom",
+            "de": "Robo-Bombe",
+            "it": "Robobomba",
+            "es": "Robobomba"
+          }
+        },
+        "Inkbrush": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "JetSquelcher": {
+          "value": "Angle Shooter",
+          "locale": {
+            "ja": "\u30e9\u30a4\u30f3\u30de\u30fc\u30ab\u30fc",
+            "ko": "\ub77c\uc778 \ub9c8\ucee4",
+            "zh_TW": "\u6a19\u7dda\u5668",
+            "zh_CN": "\u6807\u7ebf\u5668",
+            "ru": "\u0423\u0433\u043b\u043e\u0441\u0442\u0440\u0435\u043b",
+            "fr": "Ricocheur",
+            "nl": "Ketskogel",
+            "de": "Winkelmarker",
+            "it": "Sparalinee",
+            "es": "Tiral\u00edneas",
+            "es_LA": "Dardo resaltador"
+          }
+        },
+        "L3Nozzlenose": {
+          "value": "Curling Bomb",
+          "locale": {
+            "ja": "\u30ab\u30fc\u30ea\u30f3\u30b0\u30dc\u30e0",
+            "ko": "\uceec\ub9c1 \ubc24",
+            "zh_TW": "\u51b0\u58fa\u70b8\u5f48",
+            "zh_CN": "\u51b0\u58f6\u70b8\u5f39",
+            "ru": "\u041a\u0435\u0440\u043b\u0438\u043d\u0433-\u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe curling",
+            "nl": "Curlingbom",
+            "de": "Curling-Bombe",
+            "it": "Bomba curling",
+            "es": "Bomba deslizante"
+          }
+        },
+        "LunaBlaster": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "MiniSplatling": {
+          "value": "Burst Bomb",
+          "locale": {
+            "ja": "\u30af\u30a4\u30c3\u30af\u30dc\u30e0",
+            "ko": "\ud035 \ubc24",
+            "zh_TW": "\u5feb\u901f\u70b8\u5f48",
+            "zh_CN": "\u5feb\u901f\u70b8\u5f39",
+            "ru": "\u0420\u0430\u0437\u0440\u044b\u0432\u043d\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe ballon",
+            "nl": "Ballonbom",
+            "de": "Insta-Bombe",
+            "it": "Granata",
+            "es": "Bomba R\u00e1pida",
+            "es_LA": "Globo Entintado"
+          }
+        },
+        "NZAP'85": {
+          "value": "Suction Bomb",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30d0\u30f3\u30dc\u30e0",
+            "ko": "\ube68\ud310 \ubc24",
+            "zh_TW": "\u5438\u76e4\u70b8\u5f48",
+            "zh_CN": "\u5438\u76d8\u70b8\u5f39",
+            "ru": "\u0411\u043e\u043c\u0431\u0430 \u043d\u0430 \u043f\u0440\u0438\u0441\u043e\u0441\u043a\u0435",
+            "fr": "Bombe gluante",
+            "nl": "Kleefbom",
+            "de": "Haftbombe",
+            "it": "Appiccibomba",
+            "es": "Bomba ventosa",
+            "es_LA": "Bomba pegajosa"
+          }
+        },
+        "Nautilus47": {
+          "value": "Point Sensor",
+          "locale": {
+            "ja": "\u30dd\u30a4\u30f3\u30c8\u30bb\u30f3\u30b5\u30fc",
+            "ko": "\ud3ec\uc778\ud2b8 \uc13c\uc11c",
+            "zh_TW": "\u5b9a\u9ede\u5075\u6e2c\u5668",
+            "zh_CN": "\u5b9a\u70b9\u4fa6\u6d4b\u5668",
+            "ru": "\u041c\u0430\u0440\u043a\u0435\u0440 \u0434\u0432\u0438\u0436\u0435\u043d\u0438\u044f",
+            "fr": "D\u00e9tecteur",
+            "nl": "Detector",
+            "de": "Detektor",
+            "it": "Cimice",
+            "es": "Rastreador"
+          }
+        },
+        "Octobrush": {
+          "value": "Suction Bomb",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30d0\u30f3\u30dc\u30e0",
+            "ko": "\ube68\ud310 \ubc24",
+            "zh_TW": "\u5438\u76e4\u70b8\u5f48",
+            "zh_CN": "\u5438\u76d8\u70b8\u5f39",
+            "ru": "\u0411\u043e\u043c\u0431\u0430 \u043d\u0430 \u043f\u0440\u0438\u0441\u043e\u0441\u043a\u0435",
+            "fr": "Bombe gluante",
+            "nl": "Kleefbom",
+            "de": "Haftbombe",
+            "it": "Appiccibomba",
+            "es": "Bomba ventosa",
+            "es_LA": "Bomba pegajosa"
+          }
+        },
+        "RangeBlaster": {
+          "value": "Suction Bomb",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30d0\u30f3\u30dc\u30e0",
+            "ko": "\ube68\ud310 \ubc24",
+            "zh_TW": "\u5438\u76e4\u70b8\u5f48",
+            "zh_CN": "\u5438\u76d8\u70b8\u5f39",
+            "ru": "\u0411\u043e\u043c\u0431\u0430 \u043d\u0430 \u043f\u0440\u0438\u0441\u043e\u0441\u043a\u0435",
+            "fr": "Bombe gluante",
+            "nl": "Kleefbom",
+            "de": "Haftbombe",
+            "it": "Appiccibomba",
+            "es": "Bomba ventosa",
+            "es_LA": "Bomba pegajosa"
+          }
+        },
+        "RapidBlaster": {
+          "value": "Ink Mine",
+          "locale": {
+            "ja": "\u30c8\u30e9\u30c3\u30d7",
+            "ko": "\ud2b8\ub7a9",
+            "ru": "\u041c\u0438\u043d\u044b",
+            "nl": "Inktmijn",
+            "de": "Tintenmine",
+            "it": "Mina",
+            "fr_CA": "Mine d'encre",
+            "es": "Bomba Trampa",
+            "es_LA": "Mina de tinta",
+            "fr": "Mine"
+          }
+        },
+        "RapidBlasterPro": {
+          "value": "Toxic Mist",
+          "locale": {
+            "ja": "\u30dd\u30a4\u30ba\u30f3\u30df\u30b9\u30c8",
+            "ko": "\ud3ec\uc774\uc98c \ubbf8\uc2a4\ud2b8",
+            "zh_TW": "\u6bd2\u9727",
+            "zh_CN": "\u6bd2\u96fe",
+            "ru": "\u0415\u0434\u043a\u0438\u0439 \u0442\u0443\u043c\u0430\u043d",
+            "fr": "Brume toxique",
+            "nl": "Gifmist",
+            "de": "Sepitox-Nebel",
+            "it": "Nebbia tossica",
+            "es": "Nebulizador"
+          }
+        },
+        "REEFLUX450": {
+          "value": "Curling Bomb",
+          "locale": {
+            "ja": "\u30ab\u30fc\u30ea\u30f3\u30b0\u30dc\u30e0",
+            "ko": "\uceec\ub9c1 \ubc24",
+            "zh_TW": "\u51b0\u58fa\u70b8\u5f48",
+            "zh_CN": "\u51b0\u58f6\u70b8\u5f39",
+            "ru": "\u041a\u0435\u0440\u043b\u0438\u043d\u0433-\u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe curling",
+            "nl": "Curlingbom",
+            "de": "Curling-Bombe",
+            "it": "Bomba curling",
+            "es": "Bomba deslizante"
+          }
+        },
+        "Slosher": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "SloshingMachine": {
+          "value": "Fizzy Bomb",
+          "locale": {
+            "ja": "\u30bf\u30f3\u30b5\u30f3\u30dc\u30e0",
+            "ko": "\ud0c4\uc0b0 \ubc24",
+            "zh_TW": "\u78b3\u9178\u70b8\u5f48",
+            "zh_CN": "\u78b3\u9178\u70b8\u5f39",
+            "ru": "\u0421\u043e\u0434\u043e\u0432\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe soda",
+            "nl": "Bomblikje",
+            "de": "Sprudel-Bombe",
+            "it": "Bomba a gassosa",
+            "es": "Bomba carb\u00f3nica"
+          }
+        },
+        "Splashomatic": {
+          "value": "Burst Bomb",
+          "locale": {
+            "ja": "\u30af\u30a4\u30c3\u30af\u30dc\u30e0",
+            "ko": "\ud035 \ubc24",
+            "zh_TW": "\u5feb\u901f\u70b8\u5f48",
+            "zh_CN": "\u5feb\u901f\u70b8\u5f39",
+            "ru": "\u0420\u0430\u0437\u0440\u044b\u0432\u043d\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe ballon",
+            "nl": "Ballonbom",
+            "de": "Insta-Bombe",
+            "it": "Granata",
+            "es": "Bomba R\u00e1pida",
+            "es_LA": "Globo Entintado"
+          }
+        },
+        "SplatBrella": {
+          "value": "Sprinkler",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30ea\u30f3\u30af\u30e9\u30fc",
+            "ko": "\uc2a4\ud504\ub9c1\ud074\ub7ec",
+            "zh_TW": "\u7051\u58a8\u5668",
+            "zh_CN": "\u6d12\u58a8\u5668",
+            "ru": "\u0420\u0430\u0441\u043f\u044b\u043b\u044f\u0442\u043e\u0440",
+            "nl": "Inktsprinkler",
+            "de": "Sprinkler",
+            "it": "Spruzzatore",
+            "es": "Aspersor",
+            "fr_CA": "Gicleur",
+            "fr": "Fontaine"
+          }
+        },
+        "SplatCharger": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "SplatDualies": {
+          "value": "Suction Bomb",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30d0\u30f3\u30dc\u30e0",
+            "ko": "\ube68\ud310 \ubc24",
+            "zh_TW": "\u5438\u76e4\u70b8\u5f48",
+            "zh_CN": "\u5438\u76d8\u70b8\u5f39",
+            "ru": "\u0411\u043e\u043c\u0431\u0430 \u043d\u0430 \u043f\u0440\u0438\u0441\u043e\u0441\u043a\u0435",
+            "fr": "Bombe gluante",
+            "nl": "Kleefbom",
+            "de": "Haftbombe",
+            "it": "Appiccibomba",
+            "es": "Bomba ventosa",
+            "es_LA": "Bomba pegajosa"
+          }
+        },
+        "SplatRoller": {
+          "value": "Curling Bomb",
+          "locale": {
+            "ja": "\u30ab\u30fc\u30ea\u30f3\u30b0\u30dc\u30e0",
+            "ko": "\uceec\ub9c1 \ubc24",
+            "zh_TW": "\u51b0\u58fa\u70b8\u5f48",
+            "zh_CN": "\u51b0\u58f6\u70b8\u5f39",
+            "ru": "\u041a\u0435\u0440\u043b\u0438\u043d\u0433-\u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe curling",
+            "nl": "Curlingbom",
+            "de": "Curling-Bombe",
+            "it": "Bomba curling",
+            "es": "Bomba deslizante"
+          }
+        },
+        "SplatanaStamper": {
+          "value": "Burst Bomb",
+          "locale": {
+            "ja": "\u30af\u30a4\u30c3\u30af\u30dc\u30e0",
+            "ko": "\ud035 \ubc24",
+            "zh_TW": "\u5feb\u901f\u70b8\u5f48",
+            "zh_CN": "\u5feb\u901f\u70b8\u5f39",
+            "ru": "\u0420\u0430\u0437\u0440\u044b\u0432\u043d\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe ballon",
+            "nl": "Ballonbom",
+            "de": "Insta-Bombe",
+            "it": "Granata",
+            "es": "Bomba R\u00e1pida",
+            "es_LA": "Globo Entintado"
+          }
+        },
+        "SplatanaWiper": {
+          "value": "Torpedo",
+          "locale": {
+            "ja": "\u30c8\u30fc\u30d4\u30fc\u30c9",
+            "ko": "\ud1a0\ud53c\ub3c4",
+            "zh_TW": "\u9b5a\u96f7",
+            "zh_CN": "\u9c7c\u96f7",
+            "ru": "\u0422\u043e\u0440\u043f\u0435\u0434\u043d\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bentorpille",
+            "nl": "Torpedobom",
+            "de": "Torpedo",
+            "it": "Torpedinatore",
+            "es": "Torpedo"
+          }
+        },
+        "Splatterscope": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "Splattershot": {
+          "value": "Suction Bomb",
+          "locale": {
+            "ja": "\u30ad\u30e5\u30fc\u30d0\u30f3\u30dc\u30e0",
+            "ko": "\ube68\ud310 \ubc24",
+            "zh_TW": "\u5438\u76e4\u70b8\u5f48",
+            "zh_CN": "\u5438\u76d8\u70b8\u5f39",
+            "ru": "\u0411\u043e\u043c\u0431\u0430 \u043d\u0430 \u043f\u0440\u0438\u0441\u043e\u0441\u043a\u0435",
+            "fr": "Bombe gluante",
+            "nl": "Kleefbom",
+            "de": "Haftbombe",
+            "it": "Appiccibomba",
+            "es": "Bomba ventosa",
+            "es_LA": "Bomba pegajosa"
+          }
+        },
+        "SplattershotJr": {
+          "value": "Splat Bomb",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30dc\u30e0",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \ubd04",
+            "zh_TW": "\u65af\u666e\u62c9\u70b8\u5f48",
+            "zh_CN": "\u65af\u666e\u62c9\u70b8\u5f39",
+            "ru": "\u0411\u0440\u044b\u0437\u0433\u0430\u044e\u0449\u0430\u044f \u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe splash",
+            "nl": "Klodderbom",
+            "de": "Klecksbombe",
+            "it": "Bomba splash",
+            "es": "Bomba b\u00e1sica",
+            "es_LA": "Plasbomba"
+          }
+        },
+        "SplattershotPro": {
+          "value": "Angle Shooter",
+          "locale": {
+            "ja": "\u30e9\u30a4\u30f3\u30de\u30fc\u30ab\u30fc",
+            "ko": "\ub77c\uc778 \ub9c8\ucee4",
+            "zh_TW": "\u6a19\u7dda\u5668",
+            "zh_CN": "\u6807\u7ebf\u5668",
+            "ru": "\u0423\u0433\u043b\u043e\u0441\u0442\u0440\u0435\u043b",
+            "fr": "Ricocheur",
+            "nl": "Ketskogel",
+            "de": "Winkelmarker",
+            "it": "Sparalinee",
+            "es": "Tiral\u00edneas",
+            "es_LA": "Dardo resaltador"
+          }
+        },
+        "Splooshomatic": {
+          "value": "Curling Bomb",
+          "locale": {
+            "ja": "\u30ab\u30fc\u30ea\u30f3\u30b0\u30dc\u30e0",
+            "ko": "\uceec\ub9c1 \ubc24",
+            "zh_TW": "\u51b0\u58fa\u70b8\u5f48",
+            "zh_CN": "\u51b0\u58f6\u70b8\u5f39",
+            "ru": "\u041a\u0435\u0440\u043b\u0438\u043d\u0433-\u0431\u043e\u043c\u0431\u0430",
+            "fr": "Bombe curling",
+            "nl": "Curlingbom",
+            "de": "Curling-Bombe",
+            "it": "Bomba curling",
+            "es": "Bomba deslizante"
+          }
+        },
+        "Squeezer": {
+          "value": "Splash Wall",
+          "locale": {
+            "ja": "\u30b9\u30d7\u30e9\u30c3\u30b7\u30e5\u30b7\u30fc\u30eb\u30c9",
+            "ko": "\uc2a4\ud50c\ub798\uc2dc \uc2e4\ub4dc",
+            "zh_TW": "\u65af\u666e\u62c9\u9632\u8b77\u7246",
+            "zh_CN": "\u65af\u666e\u62c9\u9632\u62a4\u5899",
+            "ru": "\u0427\u0435\u0440\u043d\u0438\u043b\u044c\u043d\u044b\u0439 \u0437\u0430\u043d\u0430\u0432\u0435\u0441",
+            "fr": "Mur d'encre",
+            "nl": "Inktgordijn",
+            "de": "Tintenwall",
+            "it": "Muro di colore",
+            "es": "Tel\u00f3n de Tinta",
+            "es_LA": "Barricada"
+          }
+        },
+        "TentaBrella": {
+          "value": "Squid Beakon",
+          "locale": {
+            "ja": "\u30b8\u30e3\u30f3\u30d7\u30d3\u30fc\u30b3\u30f3",
+            "ko": "\uc810\ud504 \ube44\ucee8",
+            "zh_TW": "\u8df3\u8e8d\u4fe1\u6a19",
+            "zh_CN": "\u8df3\u8dc3\u4fe1\u6807",
+            "ru": "\u041f\u0440\u044b\u0436\u043a\u043e\u0432\u044b\u0439 \u043c\u0430\u044f\u0447\u043e\u043a",
+            "fr": "Balise de saut",
+            "nl": "Springschotel",
+            "de": "Sprungboje",
+            "it": "Trasferitore",
+            "es": "Baliza transportadora",
+            "es_LA": "Baliza"
+          }
+        },
+        "TriSlosher": {
+          "value": "Toxic Mist",
+          "locale": {
+            "ja": "\u30dd\u30a4\u30ba\u30f3\u30df\u30b9\u30c8",
+            "ko": "\ud3ec\uc774\uc98c \ubbf8\uc2a4\ud2b8",
+            "zh_TW": "\u6bd2\u9727",
+            "zh_CN": "\u6bd2\u96fe",
+            "ru": "\u0415\u0434\u043a\u0438\u0439 \u0442\u0443\u043c\u0430\u043d",
+            "fr": "Brume toxique",
+            "nl": "Gifmist",
+            "de": "Sepitox-Nebel",
+            "it": "Nebbia tossica",
+            "es": "Nebulizador"
+          }
+        },
+        "TriStringer": {
+          "value": "Toxic Mist",
+          "locale": {
+            "ja": "\u30dd\u30a4\u30ba\u30f3\u30df\u30b9\u30c8",
+            "ko": "\ud3ec\uc774\uc98c \ubbf8\uc2a4\ud2b8",
+            "zh_TW": "\u6bd2\u9727",
+            "zh_CN": "\u6bd2\u96fe",
+            "ru": "\u0415\u0434\u043a\u0438\u0439 \u0442\u0443\u043c\u0430\u043d",
+            "fr": "Brume toxique",
+            "nl": "Gifmist",
+            "de": "Sepitox-Nebel",
+            "it": "Nebbia tossica",
+            "es": "Nebulizador"
+          }
+        },
+        "UndercoverBrella": {
+          "value": "Ink Mine",
+          "locale": {
+            "ja": "\u30c8\u30e9\u30c3\u30d7",
+            "ko": "\ud2b8\ub7a9",
+            "ru": "\u041c\u0438\u043d\u044b",
+            "nl": "Inktmijn",
+            "de": "Tintenmine",
+            "it": "Mina",
+            "fr_CA": "Mine d'encre",
+            "es": "Bomba Trampa",
+            "es_LA": "Mina de tinta",
+            "fr": "Mine"
+          }
+        }
+      }
+    }
+  ],
   "uncropped_edge": [
       "u",
       "d",

--- a/utilities/get_icons_from_inkipedia/get_icons_from_inkipedia.py
+++ b/utilities/get_icons_from_inkipedia/get_icons_from_inkipedia.py
@@ -174,7 +174,7 @@ def write_configs(config_dict, sub_names, special_names):
             "sub"
         ],
         "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
-        "extra_data": [sub_names]
+        "metadata": [sub_names]
     }
 
     with open(f"{sub_path}/config.json", "wt", encoding="utf-8") as f:
@@ -190,7 +190,7 @@ def write_configs(config_dict, sub_names, special_names):
             "special"
         ],
         "credits": "Assets ripped from Inkipedia (https://splatoonwiki.org/)",
-        "extra_data": [special_names]
+        "metadata": [special_names]
     }
 
     with open(f"{special_path}/config.json", "wt", encoding="utf-8") as f:


### PR DESCRIPTION
- Splatoon 3
  - Added extra metadata for Sub-weapons and Special weapons asset packs
    - Will require an update to the software to export and to the asset website to display