### PR TITLE
Add script to create resized smaller logos for every logo

### DIFF
--- a/.github/workflows/update_assets.yml
+++ b/.github/workflows/update_assets.yml
@@ -97,6 +97,21 @@ jobs:
             echo "No changes to commit"
           fi
 
+      # Create small logos
+      - name: Create small logos
+        run: |
+          pip install pillow
+          python scripts/small_logo.py
+          git config --global user.name 'Buildbot'
+          git config --global user.email 'buildbot@users.noreply.github.com'
+          git add .
+          if ! git diff --cached --quiet; then
+            git commit -m "Add small logos"
+            git push origin main
+          else
+            echo "No changes to commit"
+          fi
+
       # Run assets build logic
       - name: execute py script
         run: |

--- a/scripts/small_logo.py
+++ b/scripts/small_logo.py
@@ -1,0 +1,20 @@
+import os
+from PIL import Image
+
+def resize_logo(base_dir):
+	for root, _, files in os.walk(base_dir):
+		for file in files:
+			if file == 'logo.png':
+				logo_path = os.path.join(root, file)
+				small_logo_path = os.path.join(root, 'logo_small.png')
+				if not os.path.exists(small_logo_path):
+					img = Image.open(logo_path)
+					width_percent = (128 / float(img.size[0]))
+					height_size = int((float(img.size[1]) * float(width_percent)))
+					img = img.resize((128, height_size), Image.LANCZOS)
+					img.save(small_logo_path)
+					print(f'Resized and saved: {small_logo_path}')
+
+if __name__ == "__main__":
+	base_dir = 'games'
+	resize_logo(base_dir)


### PR DESCRIPTION
This is useful for the web tool I'm building. I'd like to be able to display the game logo when scrolling through the list of games, but it's unnecessary to load 700kb logos for every game, when I only plan on displaying it at a small size. I can imagine there are likely other uses for a small logo to be used in place of the large one as well.